### PR TITLE
fixed bug with comment.path added pinned comments

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -104,6 +104,8 @@
   "@chat": {},
   "admin": "admin",
   "@admin": {},
+  "pinned": "pinned",
+  "@pinned": {},
   "by": "by",
   "@by": {},
   "not_a_mod_or_admin": "Not a moderator or admin.",

--- a/lib/comment_tree.dart
+++ b/lib/comment_tree.dart
@@ -58,16 +58,19 @@ class CommentTree {
         // comments store a parth variable that can be used to traverse the comment tree
         // example: path: "0.{commentId}.{otherCommentId}.{yetAnotherCommentId]"
         final commentHierarchy = el.comment.path.split('.');
-        if (int.parse(commentHierarchy[commentHierarchy.length - 2]) ==
-            parent.comment.comment.id) {
+        if (commentHierarchy.length - 2 > 0 &&
+            int.parse(commentHierarchy[commentHierarchy.length - 2]) ==
+                parent.comment.comment.id) {
           parent.children.add(gatherChildren(CommentTree(el)));
         }
       }
       return parent;
     }
 
+    // pinned comment denoted by a path of 0
     final topLevelParents = comments
-        .where((e) => e.comment.path.split('.').length == 2)
+        .where((e) =>
+            e.comment.path.split('.').length == 2 || e.comment.path == '0')
         .map(CommentTree.new);
 
     final result = topLevelParents.map(gatherChildren).toList();

--- a/lib/pages/full_post/comment_section.dart
+++ b/lib/pages/full_post/comment_section.dart
@@ -106,6 +106,11 @@ class CommentSection extends StatelessWidget {
                 ),
               )
             else ...[
+              for (final com in store.pinnedComments!)
+                CommentWidget.fromCommentView(
+                  com,
+                  key: ValueKey(com),
+                ),
               for (final com in store.newComments)
                 CommentWidget.fromCommentView(
                   com,

--- a/lib/pages/full_post/full_post_store.dart
+++ b/lib/pages/full_post/full_post_store.dart
@@ -36,6 +36,9 @@ abstract class _FullPostStore with Store {
   List<CommentView>? postComments;
 
   @observable
+  List<CommentView>? pinnedComments;
+
+  @observable
   ObservableList<CommentView> newComments = ObservableList<CommentView>();
 
   @observable
@@ -80,7 +83,7 @@ abstract class _FullPostStore with Store {
     final commentsResult = await commentsState.runLemmy(
         instanceHost,
         GetComments(
-            postId: postId, type: CommentListingType.all, maxDepth: 20));
+            postId: postId, type: CommentListingType.all, maxDepth: 10));
 
     if (result != null) {
       postStore ??= PostStore(result.postView);
@@ -90,6 +93,9 @@ abstract class _FullPostStore with Store {
 
     if (commentsResult != null) {
       postComments = commentsResult;
+      pinnedComments = commentsResult
+          .where((element) => element.comment.path == '0')
+          .toList();
     }
   }
 

--- a/lib/pages/full_post/full_post_store.g.dart
+++ b/lib/pages/full_post/full_post_store.g.dart
@@ -70,6 +70,22 @@ mixin _$FullPostStore on _FullPostStore, Store {
     });
   }
 
+  late final _$pinnedCommentsAtom =
+      Atom(name: '_FullPostStore.pinnedComments', context: context);
+
+  @override
+  List<CommentView>? get pinnedComments {
+    _$pinnedCommentsAtom.reportRead();
+    return super.pinnedComments;
+  }
+
+  @override
+  set pinnedComments(List<CommentView>? value) {
+    _$pinnedCommentsAtom.reportWrite(value, super.pinnedComments, () {
+      super.pinnedComments = value;
+    });
+  }
+
   late final _$newCommentsAtom =
       Atom(name: '_FullPostStore.newComments', context: context);
 
@@ -164,6 +180,7 @@ mixin _$FullPostStore on _FullPostStore, Store {
     return '''
 fullPostView: ${fullPostView},
 postComments: ${postComments},
+pinnedComments: ${pinnedComments},
 newComments: ${newComments},
 sorting: ${sorting},
 postStore: ${postStore},

--- a/lib/widgets/comment/comment.dart
+++ b/lib/widgets/comment/comment.dart
@@ -234,6 +234,11 @@ class _CommentWidget extends StatelessWidget {
                           L10n.of(context).admin.toUpperCase(),
                           theme.colorScheme.secondary,
                         ),
+                      if (comment.path == '0')
+                        _CommentTag(
+                          L10n.of(context).pinned.toUpperCase(),
+                          Colors.orangeAccent,
+                        ),
                       if (creator.banned)
                         const _CommentTag('BANNED', Colors.red),
                       if (store.comment.creatorBannedFromCommunity)


### PR DESCRIPTION
Fixed an issue with the comment.path that replaced the parentId logic for building comment trees. Need to check for negative index and need to build comment trees for pinned paths (comment.path == '0')

![image](https://github.com/liftoff-app/liftoff/assets/6200670/49678e4b-f766-4e3a-8810-dbea02cc03bd)
