### PR TITLE
38 image opening closing animation is slow

### DIFF
--- a/lib/pages/settings/settings.dart
+++ b/lib/pages/settings/settings.dart
@@ -95,6 +95,13 @@ class AppearanceConfigPage extends StatelessWidget {
                 store.amoledDarkMode = checked;
               },
             ),
+            SwitchListTile.adaptive(
+              title: const Text('Disable Animations'),
+              value: store.disableAnimations,
+              onChanged: (checked) {
+                store.disableAnimations = checked;
+              },
+            ),
             const SizedBox(height: 12),
             const _SectionHeading('Post Style'),
             SwitchListTile.adaptive(

--- a/lib/stores/config_store.dart
+++ b/lib/stores/config_store.dart
@@ -49,6 +49,10 @@ abstract class _ConfigStore with Store {
   @JsonKey(defaultValue: false)
   bool amoledDarkMode = false;
 
+  @observable
+  @JsonKey(defaultValue: false)
+  bool disableAnimations = false;
+
   // default value is set in the `LocaleConverter.fromJson`
   @observable
   Locale locale = const Locale('en');

--- a/lib/stores/config_store.g.dart
+++ b/lib/stores/config_store.g.dart
@@ -10,6 +10,7 @@ ConfigStore _$ConfigStoreFromJson(Map<String, dynamic> json) => ConfigStore()
   ..theme =
       $enumDecodeNullable(_$ThemeModeEnumMap, json['theme']) ?? ThemeMode.system
   ..amoledDarkMode = json['amoledDarkMode'] as bool? ?? false
+  ..disableAnimations = json['disableAnimations'] as bool? ?? false
   ..locale = const LocaleConverter().fromJson(json['locale'] as String?)
   ..compactPostView = json['compactPostView'] as bool? ?? false
   ..postRoundedCorners = json['postRoundedCorners'] as bool? ?? true
@@ -26,6 +27,7 @@ Map<String, dynamic> _$ConfigStoreToJson(ConfigStore instance) =>
     <String, dynamic>{
       'theme': _$ThemeModeEnumMap[instance.theme]!,
       'amoledDarkMode': instance.amoledDarkMode,
+      'disableAnimations': instance.disableAnimations,
       'locale': const LocaleConverter().toJson(instance.locale),
       'compactPostView': instance.compactPostView,
       'postRoundedCorners': instance.postRoundedCorners,
@@ -79,6 +81,22 @@ mixin _$ConfigStore on _ConfigStore, Store {
   set amoledDarkMode(bool value) {
     _$amoledDarkModeAtom.reportWrite(value, super.amoledDarkMode, () {
       super.amoledDarkMode = value;
+    });
+  }
+
+  late final _$disableAnimationsAtom =
+      Atom(name: '_ConfigStore.disableAnimations', context: context);
+
+  @override
+  bool get disableAnimations {
+    _$disableAnimationsAtom.reportRead();
+    return super.disableAnimations;
+  }
+
+  @override
+  set disableAnimations(bool value) {
+    _$disableAnimationsAtom.reportWrite(value, super.disableAnimations, () {
+      super.disableAnimations = value;
     });
   }
 
@@ -269,6 +287,7 @@ mixin _$ConfigStore on _ConfigStore, Store {
     return '''
 theme: ${theme},
 amoledDarkMode: ${amoledDarkMode},
+disableAnimations: ${disableAnimations},
 locale: ${locale},
 compactPostView: ${compactPostView},
 postRoundedCorners: ${postRoundedCorners},

--- a/lib/util/goto.dart
+++ b/lib/util/goto.dart
@@ -6,6 +6,9 @@ import '../pages/full_post/full_post.dart';
 import '../pages/media_view.dart';
 import '../pages/user.dart';
 
+import '../stores/config_store.dart';
+import '../util/observer_consumers.dart';
+
 /// Pushes onto the navigator stack the given widget
 Future<dynamic> goTo(
   BuildContext context,
@@ -55,12 +58,28 @@ abstract class goToUser {
 void goToPost(BuildContext context, String instanceHost, int postId) =>
     Navigator.of(context).push(FullPostPage.route(postId, instanceHost));
 
-void goToMedia(BuildContext context, String url) => Navigator.push(
-      context,
-      PageRouteBuilder(
-        pageBuilder: (_, __, ___) => MediaViewPage(url),
-        opaque: false,
-        transitionsBuilder: (_, animation, __, child) =>
-            FadeTransition(opacity: animation, child: child),
+void goToMedia(BuildContext context, String url) {
+  final store = Provider.of<ConfigStore>(context, listen: false);
+
+  Navigator.push(
+    context,
+    PageRouteBuilder(
+      pageBuilder: (_, __, ___) => MediaViewPage(url),
+      opaque: false,
+      transitionsBuilder: (_, animation, __, child) =>
+          TweenAnimationBuilder<double>(
+        duration: Duration(
+          milliseconds: store.disableAnimations ? 1 : 2000,
+        ),
+        tween: Tween<double>(begin: 0, end: 1),
+        builder: (_, value, child) {
+          return Opacity(
+            opacity: value,
+            child: child,
+          );
+        },
+        child: child,
       ),
-    );
+    ),
+  );
+}

--- a/lib/util/goto.dart
+++ b/lib/util/goto.dart
@@ -69,7 +69,7 @@ void goToMedia(BuildContext context, String url) {
       transitionsBuilder: (_, animation, __, child) =>
           TweenAnimationBuilder<double>(
         duration: Duration(
-          milliseconds: store.disableAnimations ? 1 : 2000,
+          milliseconds: store.disableAnimations ? 1 : 200,
         ),
         tween: Tween<double>(begin: 0, end: 1),
         builder: (_, value, child) {


### PR DESCRIPTION
Added option in appearance settings to disable image preview animation, using a custom TweenAnimationBuilder. Uses config_store bool to switch between 1ms and 200ms.

Please code-review, I'm relatively new to flutter and this was me dipping my toe in the water on a relatively easy issue.