### PR TITLE
Remove QUERY_ALL_PACKAGES permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
   package="com.liftoffapp.liftoff">
 
   <uses-permission android:name="android.permission.INTERNET" />
-  <!-- Needed for url_launcher to work on android 11 -->
-  <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
   <application
     android:name="${applicationName}"

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -113,8 +113,12 @@ Future<bool> launchLink({
   required BuildContext context,
 }) async {
   final uri = Uri.tryParse(link);
-  if (uri != null && await ul.canLaunchUrl(uri)) {
-    await ul.launchUrl(uri);
+  if (uri != null) {
+    // Only http and https links should be opened in-app
+    final mode = uri.scheme == 'http' || uri.scheme == 'https'
+        ? ul.LaunchMode.platformDefault
+        : ul.LaunchMode.externalApplication;
+    await ul.launchUrl(uri, mode: mode);
     return true;
   } else {
     _logger.warning('Failed to launch a link: $link');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
 
   # native
   share_plus: ^7.0.2
-  url_launcher: ^6.0.3
+  url_launcher: ^6.1.11
   shared_preferences: ^2.0.5
   package_info_plus: ^4.0.2
   image_picker: ^0.8.4


### PR DESCRIPTION
Closes #88

It looks like this was only needed for  `url_launcher.canLaunchUrl()`. That's not really needed IMHO. There's no reason to launch non-HTTP URLs in-app. With `externalApplication`, the OS can handle the error case.