### PR TITLE
Issue 94 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## UNRELEASED
+- Corrected URL for comments
+
 ## v0.9.13 - 2023-06-25
 - Fixed broken API for mark as read functionality
 - Added mark all as read 

--- a/lib/util/extensions/api.dart
+++ b/lib/util/extensions/api.dart
@@ -50,7 +50,7 @@ extension UserPreferredNames on PersonSafe {
 }
 
 extension CommentLink on Comment {
-  String get link => 'https://$instanceHost/post/$postId/comment/$id';
+  String get link => 'https://$instanceHost/comment/$id';
 }
 
 // inspired by https://github.com/LemmyNet/lemmy-ui/blob/66c846ededef8c0afd5aaadca4aaedcbaeab3ee6/src/shared/utils.ts#L533


### PR DESCRIPTION
Simple fix for the changed URL for comments. My only concern here is that I have no idea when this changed. There's nothing obvious in lemmy release notes. I've done a quick check of the top three servers and a random sample from join-lemmy.org and can't find anyone using the older format.