### PR TITLE
Remove deprecated command in action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Set variables
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
 
   android-build:
     name: Android build


### PR DESCRIPTION
This fixes #4 

I followed the upgrade steps listed in the linked blog post: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/