### PR TITLE
Include instance origin in matching

### DIFF
--- a/lib/pages/communities_tab.dart
+++ b/lib/pages/communities_tab.dart
@@ -135,12 +135,14 @@ class CommunitiesTab extends HookWidget {
 
     filterCommunities(List<CommunityFollowerView> comm) {
       final matches = Fuzzy(
-        comm.map((e) => '${e.community.name}@${e.community.originInstanceHost}').toList(),
+        comm
+            .map((e) => '${e.community.name}@${e.community.originInstanceHost}')
+            .toList(),
         options: FuzzyOptions(threshold: 0.5),
       ).search(filterController.text).map((e) => e.item);
 
-      return matches
-          .map((match) => comm.firstWhere((e) => '${e.community.name}@${e.community.originInstanceHost}' == match));
+      return matches.map((match) => comm.firstWhere((e) =>
+          '${e.community.name}@${e.community.originInstanceHost}' == match));
     }
 
     toggleCollapse(int i) => isCollapsed.value =

--- a/lib/pages/communities_tab.dart
+++ b/lib/pages/communities_tab.dart
@@ -135,12 +135,12 @@ class CommunitiesTab extends HookWidget {
 
     filterCommunities(List<CommunityFollowerView> comm) {
       final matches = Fuzzy(
-        comm.map((e) => e.community.name).toList(),
+        comm.map((e) => '${e.community.name}@${e.community.originInstanceHost}').toList(),
         options: FuzzyOptions(threshold: 0.5),
       ).search(filterController.text).map((e) => e.item);
 
       return matches
-          .map((match) => comm.firstWhere((e) => e.community.name == match));
+          .map((match) => comm.firstWhere((e) => '${e.community.name}@${e.community.originInstanceHost}' == match));
     }
 
     toggleCollapse(int i) => isCollapsed.value =


### PR DESCRIPTION
This is a fix for issue #135. It seems the search was only matching on the community name, and only returning the first match with the matched community name. The issue I mentioned is fixed with this PR.

![image](https://github.com/liftoff-app/liftoff/assets/1340627/feb58f8b-7f24-4f4b-bcf3-f21a1dbb28d4)
