### PR TITLE
Fix colors on hyperlinks and buttons to match theme

### DIFF
--- a/lib/resources/theme.dart
+++ b/lib/resources/theme.dart
@@ -86,6 +86,7 @@ ThemeData _themeFactory({bool dark = false, bool amoled = false}) {
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10),
         ),
+        foregroundColor: theme.colorScheme.secondary,
       ),
     ),
     dialogTheme: DialogTheme(

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -33,6 +33,9 @@ class MarkdownText extends StatelessWidget {
             left: BorderSide(width: 2, color: theme.colorScheme.secondary),
           ),
         ),
+        a: TextStyle(
+          color: theme.colorScheme.secondary,
+        ),
         code: theme.textTheme.bodyLarge
             // TODO: use a font from google fonts maybe? the defaults aren't very pretty
             ?.copyWith(fontFamily: Platform.isIOS ? 'Courier' : 'monospace'),


### PR DESCRIPTION
In dark mode the colors on links in posts and the color of the text on buttons are the default flutter blue and don't match the rest of the color scheme. The one on the buttons is particularly unreadable.

![image](https://github.com/liftoff-app/liftoff/assets/1340627/485bc557-d4c9-48be-a573-c1b4c6dba970)

This update just makes them match the theme.

![image](https://github.com/liftoff-app/liftoff/assets/1340627/a1d613af-bc57-479d-ba85-9eca7b20520c)
