### PR TITLE
Fix new comments getting "stuck" after creation

### DIFF
--- a/lib/pages/full_post/full_post_store.dart
+++ b/lib/pages/full_post/full_post_store.dart
@@ -92,6 +92,7 @@ abstract class _FullPostStore with Store {
     }
 
     if (commentsResult != null) {
+      newComments = ObservableList<CommentView>();
       postComments = commentsResult;
       pinnedComments = commentsResult
           .where((element) => element.comment.path == '0')


### PR DESCRIPTION
This is a fix for #114. Seems new comments are pushed into the "newComments" ObservableList, but as far as I can tell this is just for keeping the new comment when you post a new comment. Clearing this list fixes the issue.