### PR TITLE
FIX: Wrong community reported for account posts

### DIFF
--- a/lib/widgets/post/post_info_section.dart
+++ b/lib/widgets/post/post_info_section.dart
@@ -70,12 +70,12 @@ class PostInfoSection extends HookWidget {
                           style: TextStyle(fontWeight: FontWeight.w300),
                         ),
                         TextSpan(
-                          text: post.post.originInstanceHost,
+                          text: post.post.instanceHost,
                           style: const TextStyle(fontWeight: FontWeight.w600),
                           recognizer: TapGestureRecognizer()
                             ..onTap = () => Navigator.of(context).push(
                                   InstancePage.route(
-                                    post.post.originInstanceHost,
+                                    post.post.instanceHost,
                                   ),
                                 ),
                         ),
@@ -84,7 +84,7 @@ class PostInfoSection extends HookWidget {
                           TextSpan(
                             style: TextStyle(
                                 fontSize: configStore.postHeaderFontSize - 2),
-                            text: ' · via ${post.post.instanceHost}',
+                            text: ' · via ${post.post.originInstanceHost}',
                           ),
                       ],
                     ),

--- a/lib/widgets/post/post_info_section.dart
+++ b/lib/widgets/post/post_info_section.dart
@@ -70,21 +70,21 @@ class PostInfoSection extends HookWidget {
                           style: TextStyle(fontWeight: FontWeight.w300),
                         ),
                         TextSpan(
-                          text: post.post.instanceHost,
+                          text: post.community.originInstanceHost,
                           style: const TextStyle(fontWeight: FontWeight.w600),
                           recognizer: TapGestureRecognizer()
                             ..onTap = () => Navigator.of(context).push(
                                   InstancePage.route(
-                                    post.post.instanceHost,
+                                    post.community.originInstanceHost,
                                   ),
                                 ),
                         ),
-                        if (post.post.originInstanceHost !=
+                        if (post.community.originInstanceHost !=
                             post.post.instanceHost)
                           TextSpan(
                             style: TextStyle(
                                 fontSize: configStore.postHeaderFontSize - 2),
-                            text: ' · via ${post.post.originInstanceHost}',
+                            text: ' · via ${post.post.instanceHost}',
                           ),
                       ],
                     ),


### PR DESCRIPTION
This is a fix for #81

For some reason the header was using `${post.community.name}@${post.post.originInstanceHost}` instead of `post.post.instanceHost`. I looked into it and `instanceHost` is the instance *that the post made on*, e.x. if a post is in !mycommunity@myinstance.com `instanceHost` will be myinstance.com. While `originInstanceHost` is the instance that *the post comes from*. It's based on the `ap_id` field in the API requests (or `apId` property in the API client library) which returns the URL you would get if you click the fediverse pentagram on a post or comment, so if a post comes from a user in beehaw.org, the `ap_id` field would be something like "https://beehaw.org/post/12345". I was confused looking at it, too, so I dug into it to be sure, but switching them over like this should be all that's needed.