### PR TITLE
Improve comment scrolling performance

### DIFF
--- a/lib/pages/full_post/comment_section.dart
+++ b/lib/pages/full_post/comment_section.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
-import '../../hooks/stores.dart';
 import '../../stores/accounts_store.dart';
-import '../../stores/config_store.dart';
 import '../../util/observer_consumers.dart';
 import '../../widgets/bottom_safe.dart';
 import '../../widgets/comment/comment.dart';
@@ -11,94 +8,86 @@ import '../../widgets/failed_to_load.dart';
 import 'full_post_store.dart';
 
 /// Manages comments section, sorts them
-class CommentSection extends HookWidget {
-  const CommentSection({super.key});
+class CommentSection {
+  static List<Widget> buildComments(BuildContext context, FullPostStore store) {
+    final sort = store.sorting;
 
-  @override
-  Widget build(BuildContext context) {
-    final defaultCommentSort =
-        useStore((ConfigStore store) => store.defaultCommentSort);
+    final fullPostView = store.fullPostView;
+    final postComments = store.postComments;
 
-    final sort = useState(defaultCommentSort);
+    // error & spinner handling
+    if (fullPostView == null) {
+      if (store.fullPostState.errorTerm != null) {
+        return [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 30),
+            child: FailedToLoad(
+                message: 'ERROR: Comments failed to load. '
+                    '${store.fullPostState.errorTerm}',
+                refresh: () => store.refresh(context
+                    .read<AccountsStore>()
+                    .defaultUserDataFor(store.instanceHost)
+                    ?.jwt)),
+          )
+        ];
+      } else {
+        return [
+          const Padding(
+            padding: EdgeInsets.only(top: 40),
+            child: Center(child: CircularProgressIndicator.adaptive()),
+          )
+        ];
+      }
+    }
 
-    return ObserverBuilder<FullPostStore>(
-      builder: (context, store) {
-        final fullPostView = store.fullPostView;
-        final postComments = store.postComments;
-
-        // error & spinner handling
-        if (fullPostView == null) {
-          if (store.fullPostState.errorTerm != null) {
-            return Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 30),
-              child: FailedToLoad(
-                  message: 'ERROR: Comments failed to load. '
-                      '${store.fullPostState.errorTerm}',
-                  refresh: () => store.refresh(context
-                      .read<AccountsStore>()
-                      .defaultUserDataFor(store.instanceHost)
-                      ?.jwt)),
-            );
-          } else {
-            return const Padding(
-              padding: EdgeInsets.only(top: 40),
-              child: Center(child: CircularProgressIndicator.adaptive()),
-            );
-          }
-        }
-
-        return Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 600),
-            child: Column(
-              children: [
-                CommentListOptions(
-                    onSortChanged: (newSort) {
-                      sort.value = newSort;
-                      store.updateSorting(newSort);
-                    },
-                    sortValue: sort.value),
-                // sorting menu goes here
-                if (postComments != null && postComments.isEmpty)
-                  const Padding(
-                    padding: EdgeInsets.symmetric(vertical: 50),
-                    child: Text(
-                      'no comments yet',
-                      style: TextStyle(fontStyle: FontStyle.italic),
-                    ),
-                  )
-                else ...[
-                  for (final com in store.pinnedComments!)
-                    CommentWidget.fromCommentView(
-                      com,
-                      key: ValueKey(com),
-                    ),
-                  for (final com in store.newComments)
-                    CommentWidget.fromCommentView(
-                      com,
-                      detached: false,
-                      key: ValueKey(com),
-                    ),
-                  // if (store.sorting == CommentSortType.chat)
-                  //   for (final com in postComments!)
-                  //     CommentWidget.fromCommentView(
-                  //       com,
-                  //       detached: false,
-                  //       key: ValueKey(com),
-                  //     )
-                  // else
-                  for (final com in store.sortedCommentTree!)
-                    CommentWidget(
-                      com,
-                      key: ValueKey(com),
-                    ),
-                  const BottomSafe.fab(),
-                ]
-              ],
+    return [
+      CommentListOptions(onSortChanged: store.updateSorting, sortValue: sort),
+      // sorting menu goes here
+      if (postComments != null && postComments.isEmpty)
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 50),
+          child: Text(
+            'no comments yet',
+            style: TextStyle(fontStyle: FontStyle.italic),
+          ),
+        )
+      else ...[
+        for (final com in store.pinnedComments!)
+          _centeredWithConstraints(
+            child: CommentWidget.fromCommentView(
+              com,
+              key: ValueKey(com),
             ),
           ),
-        );
-      },
-    );
+        for (final com in store.newComments)
+          _centeredWithConstraints(
+            child: CommentWidget.fromCommentView(
+              com,
+              detached: false,
+              key: ValueKey(com),
+            ),
+          ),
+        // if (store.sorting == CommentSortType.chat)
+        //   for (final com in postComments!)
+        //     CommentWidget.fromCommentView(
+        //       com,
+        //       detached: false,
+        //       key: ValueKey(com),
+        //     )
+        // else
+        for (final com in store.sortedCommentTree!)
+          _centeredWithConstraints(
+            child: CommentWidget(
+              com,
+              key: ValueKey(com),
+            ),
+          ),
+        const BottomSafe.fab(),
+      ]
+    ];
   }
+
+  static Widget _centeredWithConstraints({required Widget child}) => Center(
+      child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600), child: child));
 }

--- a/lib/pages/full_post/full_post.dart
+++ b/lib/pages/full_post/full_post.dart
@@ -171,7 +171,7 @@ class FullPostPage extends HookWidget {
                 children: [
                   const SizedBox(height: 15),
                   PostTile.fromPostStore(postStore),
-                  const CommentSection(),
+                  ...CommentSection.buildComments(context, store),
                 ],
               ),
             ),


### PR DESCRIPTION
Make comments direct children of the `ListView` in the `FullPostPage`. This allows them to be properly virtualized, increasing performance drastically on posts with lost of comments.

fixes #51