### PR TITLE
Default list on home tab follows selected user profile

### DIFF
--- a/lib/pages/home_tab.dart
+++ b/lib/pages/home_tab.dart
@@ -40,6 +40,7 @@ class HomeTab extends HookWidget {
         useStore((ConfigStore store) => store.showEverythingFeed);
 
     final selectedList = useState(_SelectedList(
+        instanceHost: accStore.defaultInstanceHost,
         listingType: accStore.hasNoAccount &&
                 defaultListingType == PostListingType.subscribed
             ? PostListingType.all


### PR DESCRIPTION
Thanks @mykdavies for the code change!

This would make it so that Liftoff will not open by default to the Everything/All feed (which is especially important imho when that feature is disabled), but rather to the All feed of the user selected on the user tab. If no user is signed in, it still defaults to the Everything feed. At some point in the future it might be beneficial for a user to be able to pick a specific feed to be their default.