### PR TITLE
Temp: disable saving sort/list settings to server

### DIFF
--- a/lib/pages/manage_account.dart
+++ b/lib/pages/manage_account.dart
@@ -142,8 +142,10 @@ class _ManageAccount extends HookWidget {
         await LemmyApiV3(user.instanceHost).run(SaveUserSettings(
           showNsfw: showNsfw.value,
           theme: user.localUser.theme,
+          /* Temp: disable saving these prefs until servers are all on >v0.18.x
           defaultSortType: user.localUser.defaultSortType,
           defaultListingType: user.localUser.defaultListingType,
+          */
           interfaceLanguage: user.localUser.interfaceLanguage,
           showAvatars: user.localUser.showAvatars,
           botAccount: botAccount.value,


### PR DESCRIPTION
This a temporary fix for 0.17.x compatibility. Preferred sort method and list view are still maintained in the app.

Edit, fixes https://github.com/liftoff-app/liftoff/issues/125