### PR TITLE
Enable user to set preferred comment sorting preference

### DIFF
--- a/lib/comment_tree.dart
+++ b/lib/comment_tree.dart
@@ -43,6 +43,10 @@ enum CommentSortType {
         ? values[value]
         : values.firstWhere((e) => e.value == value);
   }
+
+    String toJson() => value;
+
+    String toString() => value;
 }
 
 extension SortCommentTreeList on List<CommentTree> {

--- a/lib/comment_tree.dart
+++ b/lib/comment_tree.dart
@@ -44,9 +44,10 @@ enum CommentSortType {
         : values.firstWhere((e) => e.value == value);
   }
 
-    String toJson() => value;
+  String toJson() => value;
 
-    String toString() => value;
+  @override
+  String toString() => value;
 }
 
 extension SortCommentTreeList on List<CommentTree> {

--- a/lib/pages/full_post/full_post_store.dart
+++ b/lib/pages/full_post/full_post_store.dart
@@ -2,6 +2,8 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../comment_tree.dart';
+import '../../hooks/stores.dart';
+import '../../stores/config_store.dart';
 import '../../util/async_store.dart';
 import '../../widgets/post/post_store.dart';
 
@@ -42,8 +44,8 @@ abstract class _FullPostStore with Store {
   ObservableList<CommentView> newComments = ObservableList<CommentView>();
 
   @observable
-  CommentSortType sorting = CommentSortType.hot;
-
+  CommentSortType sorting = useStore((ConfigStore store) => store.defaultCommentSort);
+  
   @observable
   PostStore? postStore;
 

--- a/lib/pages/full_post/full_post_store.dart
+++ b/lib/pages/full_post/full_post_store.dart
@@ -44,8 +44,9 @@ abstract class _FullPostStore with Store {
   ObservableList<CommentView> newComments = ObservableList<CommentView>();
 
   @observable
-  CommentSortType sorting = useStore((ConfigStore store) => store.defaultCommentSort);
-  
+  CommentSortType sorting =
+      useStore((ConfigStore store) => store.defaultCommentSort);
+
   @observable
   PostStore? postStore;
 

--- a/lib/pages/settings/settings.dart
+++ b/lib/pages/settings/settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:lemmy_api_client/v3.dart';
 
+import '../../comment_tree.dart';
 import '../../hooks/stores.dart';
 import '../../l10n/l10n.dart';
 import '../../stores/config_store.dart';
@@ -280,6 +281,18 @@ class GeneralConfigPage extends StatelessWidget {
                   values: SortType.values,
                   groupValue: store.defaultSortType,
                   onChanged: (value) => store.defaultSortType = value,
+                  mapValueToString: (value) => value.value,
+                ),
+              ),
+            ),
+            ListTile(
+              title: Text(L10n.of(context).comment_sort_type),
+              trailing: SizedBox(
+                width: 120,
+                child: RadioPicker<CommentSortType>(
+                  values: CommentSortType.values,
+                  groupValue: store.defaultCommentSort,
+                  onChanged: (value) => store.defaultCommentSort = value,
                   mapValueToString: (value) => value.value,
                 ),
               ),

--- a/lib/stores/config_store.dart
+++ b/lib/stores/config_store.dart
@@ -173,6 +173,6 @@ abstract class _ConfigStore with Store {
 SortType _sortTypeFromJson(String? json) =>
     json != null ? SortType.fromJson(json) : SortType.hot;
 CommentSortType _commentSortTypeFromJson(String? json) =>
-     json != null ? CommentSortType.fromJson(json) : CommentSortType.hot;
+    json != null ? CommentSortType.fromJson(json) : CommentSortType.hot;
 PostListingType _postListingTypeFromJson(String? json) =>
     json != null ? PostListingType.fromJson(json) : PostListingType.all;

--- a/lib/stores/config_store.dart
+++ b/lib/stores/config_store.dart
@@ -6,6 +6,7 @@ import 'package:lemmy_api_client/v3.dart';
 import 'package:mobx/mobx.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../comment_tree.dart';
 import '../l10n/l10n.dart';
 import '../util/async_store.dart';
 import '../util/mobx_provider.dart';
@@ -110,9 +111,9 @@ abstract class _ConfigStore with Store {
   @JsonKey(fromJson: _sortTypeFromJson)
   SortType defaultSortType = SortType.hot;
 
-  // @observable
-  // @JsonKey(fromJson: _commentSortTypeFromJson)
-  // CommentSortType defaultCommentSort = CommentSortType.hot;
+  @observable
+  @JsonKey(fromJson: _commentSortTypeFromJson)
+  CommentSortType defaultCommentSort = CommentSortType.hot;
 
   // default is set in fromJson
   @observable
@@ -171,7 +172,7 @@ abstract class _ConfigStore with Store {
 
 SortType _sortTypeFromJson(String? json) =>
     json != null ? SortType.fromJson(json) : SortType.hot;
-// CommentSortType _commentSortTypeFromJson(String? json) =>
-//     json != null ? CommentSortType.fromJson(json) : CommentSortType.hot;
+CommentSortType _commentSortTypeFromJson(String? json) =>
+     json != null ? CommentSortType.fromJson(json) : CommentSortType.hot;
 PostListingType _postListingTypeFromJson(String? json) =>
     json != null ? PostListingType.fromJson(json) : PostListingType.all;

--- a/lib/stores/config_store.g.dart
+++ b/lib/stores/config_store.g.dart
@@ -24,6 +24,8 @@ ConfigStore _$ConfigStoreFromJson(Map<String, dynamic> json) => ConfigStore()
   ..postHeaderFontSize = (json['postHeaderFontSize'] as num?)?.toDouble() ?? 15
   ..showEverythingFeed = json['showEverythingFeed'] as bool? ?? false
   ..defaultSortType = _sortTypeFromJson(json['defaultSortType'] as String?)
+  ..defaultCommentSort =
+      _commentSortTypeFromJson(json['defaultCommentSort'] as String?)
   ..defaultListingType =
       _postListingTypeFromJson(json['defaultListingType'] as String?);
 
@@ -45,6 +47,7 @@ Map<String, dynamic> _$ConfigStoreToJson(ConfigStore instance) =>
       'postHeaderFontSize': instance.postHeaderFontSize,
       'showEverythingFeed': instance.showEverythingFeed,
       'defaultSortType': instance.defaultSortType,
+      'defaultCommentSort': instance.defaultCommentSort,
       'defaultListingType': instance.defaultListingType,
     };
 
@@ -315,6 +318,22 @@ mixin _$ConfigStore on _ConfigStore, Store {
     });
   }
 
+  late final _$defaultCommentSortAtom =
+      Atom(name: '_ConfigStore.defaultCommentSort', context: context);
+
+  @override
+  CommentSortType get defaultCommentSort {
+    _$defaultCommentSortAtom.reportRead();
+    return super.defaultCommentSort;
+  }
+
+  @override
+  set defaultCommentSort(CommentSortType value) {
+    _$defaultCommentSortAtom.reportWrite(value, super.defaultCommentSort, () {
+      super.defaultCommentSort = value;
+    });
+  }
+
   late final _$defaultListingTypeAtom =
       Atom(name: '_ConfigStore.defaultListingType', context: context);
 
@@ -373,6 +392,7 @@ titleFontSize: ${titleFontSize},
 postHeaderFontSize: ${postHeaderFontSize},
 showEverythingFeed: ${showEverythingFeed},
 defaultSortType: ${defaultSortType},
+defaultCommentSort: ${defaultCommentSort},
 defaultListingType: ${defaultListingType}
     ''';
   }


### PR DESCRIPTION
This commit adds a feature (already partially implemented) allowing the user to set a default comment sorting preference. Thanks [swmarks](https://github.com/swmarks) for help troubleshooting the enum problem.