### PR TITLE
Make more colors more consistent

### DIFF
--- a/lib/resources/theme.dart
+++ b/lib/resources/theme.dart
@@ -74,7 +74,6 @@ ThemeData _themeFactory({bool dark = false, bool amoled = false}) {
     textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(
         backgroundColor: theme.colorScheme.background,
-        foregroundColor: theme.colorScheme.onSecondary,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10),
         ),
@@ -86,13 +85,15 @@ ThemeData _themeFactory({bool dark = false, bool amoled = false}) {
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10),
         ),
-        foregroundColor: theme.colorScheme.secondary,
       ),
     ),
     dialogTheme: DialogTheme(
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(10),
       ),
+    ),
+    colorScheme: theme.colorScheme.copyWith(
+      primary: theme.colorScheme.secondary,
     ),
   );
 }


### PR DESCRIPTION
So #137 is a bit of a patchy solution, since it applies the color directly to components. This moves it to the "colorScheme" instead which unilaterally applies it to components on the app. The buttons here are updated to no longer have black text:
![image](https://github.com/liftoff-app/liftoff/assets/1340627/8264d902-1ad7-4423-ac70-1a53c8ee2a3b)

The text box, text cursor, and button here are also updated:
![image](https://github.com/liftoff-app/liftoff/assets/1340627/296ad516-2ef8-42bc-b8ce-5caffd92872e)

The links update is preserved. I also checked the light theme to be sure and it looks to be unchanged:
![image](https://github.com/liftoff-app/liftoff/assets/1340627/656403ba-24c7-453f-80de-95555b1601cb)
![image](https://github.com/liftoff-app/liftoff/assets/1340627/c259fb4d-f6dc-48ce-849d-c577111f6f07)
