### PR TITLE
WIP: Anonymous account posting

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -84,6 +84,12 @@
   "@show_nsfw": {},
   "send_notifications_to_email": "Send notifications to Email",
   "@send_notifications_to_email": {},
+  "use_account_for_anon_instances": "Use this account for anonymous instances",
+  "@use_account_for_anon_instances": {},
+  "use_account_for_anon_instances_info": "For instances where you don't have an account, you can assign this account for posting or voting. Note that federation is not guaranteed. If the other instance has defederated or is under heavy load, it's possible your post or vote will be missed.",
+  "@use_account_for_anon_instances_info": {},
+  "use_account_for_anon_instances_warning": "You may only select one account for interacting with anonymous instances. If you assign this account, the other account you've selected will be deselected for this option.",
+  "@use_account_for_anon_instances_warning": {},
   "remove_account": "Remove account",
   "@remove_account": {},
   "delete_account": "Delete account",
@@ -451,6 +457,10 @@
   "add_link": "Add link",
   "@add_link": {
     "description": "title on top of a link insertion popup in a markdown editor"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Ok button on popup"
   },
   "cancel": "Cancel",
   "@cancel": {

--- a/lib/hooks/logged_in_action.dart
+++ b/lib/hooks/logged_in_action.dart
@@ -38,7 +38,7 @@ VoidCallback Function(
 VoidCallback Function(
   void Function(Jwt token) action, [
   String? message,
-]) useLoggedInAction(String instanceHost, { bool allowAnonymous = false }) {
+]) useLoggedInAction(String instanceHost, {bool allowAnonymous = false}) {
   final context = useContext();
   final store = useAccountsStore();
 

--- a/lib/hooks/logged_in_action.dart
+++ b/lib/hooks/logged_in_action.dart
@@ -38,12 +38,17 @@ VoidCallback Function(
 VoidCallback Function(
   void Function(Jwt token) action, [
   String? message,
-]) useLoggedInAction(String instanceHost) {
+]) useLoggedInAction(String instanceHost, { bool allowAnonymous = false }) {
   final context = useContext();
   final store = useAccountsStore();
 
   return (action, [message]) {
     if (store.isAnonymousFor(instanceHost)) {
+      if (allowAnonymous && store.hasAnonymousUserFor(instanceHost)) {
+        final token = store.anonymousUserDataFor(instanceHost)!.jwt;
+        return () => action(token);
+      }
+
       return () {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text(message ??
@@ -54,6 +59,7 @@ VoidCallback Function(
         ));
       };
     }
+
     final token = store.defaultUserDataFor(instanceHost)!.jwt;
     return () => action(token);
   };

--- a/lib/hooks/stores.dart
+++ b/lib/hooks/stores.dart
@@ -3,8 +3,11 @@ import 'package:mobx/mobx.dart';
 import 'package:provider/provider.dart';
 
 import '../stores/accounts_store.dart';
+import '../stores/config_store.dart';
 
 AccountsStore useAccountsStore() => useContext().watch<AccountsStore>();
+ConfigStore useConfigStore() => useContext().watch<ConfigStore>();
+
 T useAccountsStoreSelect<T>(T selector(AccountsStore store)) =>
     useContext().select<AccountsStore, T>(selector);
 

--- a/lib/pages/full_post/full_post.dart
+++ b/lib/pages/full_post/full_post.dart
@@ -37,7 +37,7 @@ class FullPostPage extends HookWidget {
     var scrollOffset = 0.0;
 
     final loggedInAction =
-        useLoggedInAction(context.read<FullPostStore>().instanceHost);
+        useLoggedInAction(context.read<FullPostStore>().instanceHost, allowAnonymous: true);
 
     return Nested(
       children: [

--- a/lib/pages/full_post/full_post.dart
+++ b/lib/pages/full_post/full_post.dart
@@ -36,8 +36,9 @@ class FullPostPage extends HookWidget {
     final shareButtonKey = GlobalKey();
     var scrollOffset = 0.0;
 
-    final loggedInAction =
-        useLoggedInAction(context.read<FullPostStore>().instanceHost, allowAnonymous: true);
+    final loggedInAction = useLoggedInAction(
+        context.read<FullPostStore>().instanceHost,
+        allowAnonymous: true);
 
     return Nested(
       children: [

--- a/lib/pages/manage_account.dart
+++ b/lib/pages/manage_account.dart
@@ -112,8 +112,8 @@ class _ManageAccount extends HookWidget {
     final showReadPosts = useState(user.localUser.showReadPosts);
     final sendNotificationsToEmail =
         useState(user.localUser.sendNotificationsToEmail);
-    final useAccountForAnonInstances =
-        useState(accountsStore.isAnonymousUser(user.person.instanceHost, user.person.name));
+    final useAccountForAnonInstances = useState(accountsStore.isAnonymousUser(
+        user.person.instanceHost, user.person.name));
     // TODO: bring back changing password
     // final newPasswordController = useTextEditingController();
     // final newPasswordVerifyController = useTextEditingController();
@@ -170,8 +170,10 @@ class _ManageAccount extends HookWidget {
         ));
 
         if (useAccountForAnonInstances.value) {
-          await accountsStore.setAnonymousAccount(user.person.instanceHost, user.person.name);
-        } else if (accountsStore.isAnonymousUser(user.person.instanceHost, user.person.name)) {
+          await accountsStore.setAnonymousAccount(
+              user.person.instanceHost, user.person.name);
+        } else if (accountsStore.isAnonymousUser(
+            user.person.instanceHost, user.person.name)) {
           await accountsStore.removeAnonymousAccount();
         }
 
@@ -448,7 +450,9 @@ class _ManageAccount extends HookWidget {
             SwitchListTile.adaptive(
               value: useAccountForAnonInstances.value,
               onChanged: (checked) async {
-                if (checked && !accountsStore.isAnonymousUser(user.person.instanceHost, user.person.name)) {
+                if (checked &&
+                    !accountsStore.isAnonymousUser(
+                        user.person.instanceHost, user.person.name)) {
                   final accepted = await showDialog<bool>(
                     context: context,
                     barrierDismissible: false, // user must tap button!

--- a/lib/pages/manage_account.dart
+++ b/lib/pages/manage_account.dart
@@ -113,7 +113,7 @@ class _ManageAccount extends HookWidget {
     final sendNotificationsToEmail =
         useState(user.localUser.sendNotificationsToEmail);
     final useAccountForAnonInstances =
-        useState(accountsStore.anonymousAccount == user.person.actorId);
+        useState(accountsStore.isAnonymousUser(user.person.instanceHost, user.person.name));
     // TODO: bring back changing password
     // final newPasswordController = useTextEditingController();
     // final newPasswordVerifyController = useTextEditingController();
@@ -170,9 +170,9 @@ class _ManageAccount extends HookWidget {
         ));
 
         if (useAccountForAnonInstances.value) {
-          accountsStore.anonymousAccount = user.person.actorId;
-        } else if (accountsStore.anonymousAccount == user.person.actorId) {
-          accountsStore.anonymousAccount = null;
+          await accountsStore.setAnonymousAccount(user.person.instanceHost, user.person.name);
+        } else if (accountsStore.isAnonymousUser(user.person.instanceHost, user.person.name)) {
+          await accountsStore.removeAnonymousAccount();
         }
 
         await accountsStore.save();
@@ -448,9 +448,7 @@ class _ManageAccount extends HookWidget {
             SwitchListTile.adaptive(
               value: useAccountForAnonInstances.value,
               onChanged: (checked) async {
-                if (checked &&
-                    accountsStore.anonymousAccount != null &&
-                    accountsStore.anonymousAccount != user.person.actorId) {
+                if (checked && !accountsStore.isAnonymousUser(user.person.instanceHost, user.person.name)) {
                   final accepted = await showDialog<bool>(
                     context: context,
                     barrierDismissible: false, // user must tap button!

--- a/lib/stores/accounts_store.dart
+++ b/lib/stores/accounts_store.dart
@@ -205,6 +205,19 @@ class AccountsStore extends ChangeNotifier {
     return anonymousAccount != null;
   }
 
+  UserData? anonymousUserDataFor(String instanceHost) {
+    final data = accounts[anonymousAccountInstance]?[anonymousAccount];
+
+    if (data != null) {
+      return UserData(
+        userId: data.userId,
+        jwt: AnonymousAccountJwt(token: data.jwt, originalInstance: anonymousAccountInstance!),
+      );
+    }
+
+    return data;
+  }
+
   /// `true` if no added instance has an account assigned to it
   bool get hasNoAccount => loggedInInstances.isEmpty;
 
@@ -340,4 +353,13 @@ class VerifyEmailException implements Exception {
 class RegistrationApplicationSentException implements Exception {
   final message = 'registration_application_sent';
   const RegistrationApplicationSentException();
+}
+
+class AnonymousAccountJwt extends Jwt {
+  final String originalInstance;
+
+  AnonymousAccountJwt({
+    required Jwt token,
+    required this.originalInstance,
+  }) : super(payload: token.payload, raw: token.raw);
 }

--- a/lib/stores/accounts_store.dart
+++ b/lib/stores/accounts_store.dart
@@ -180,13 +180,14 @@ class AccountsStore extends ChangeNotifier {
 
   /// Checks whether the given user is the anonymous user.
   bool isAnonymousUser(String instanceHost, String username) {
-    return anonymousAccountInstance == instanceHost && anonymousAccount == username;
+    return anonymousAccountInstance == instanceHost &&
+        anonymousAccount == username;
   }
 
   Future<void> setAnonymousAccount(String instanceHost, String username) {
     // These have to exist.
     accounts[instanceHost]![username]!;
-    
+
     anonymousAccountInstance = instanceHost;
     anonymousAccount = username;
     return save();
@@ -211,7 +212,8 @@ class AccountsStore extends ChangeNotifier {
     if (data != null) {
       return UserData(
         userId: data.userId,
-        jwt: AnonymousAccountJwt(token: data.jwt, originalInstance: anonymousAccountInstance!),
+        jwt: AnonymousAccountJwt(
+            token: data.jwt, originalInstance: anonymousAccountInstance!),
       );
     }
 

--- a/lib/stores/accounts_store.dart
+++ b/lib/stores/accounts_store.dart
@@ -28,6 +28,10 @@ class AccountsStore extends ChangeNotifier {
   @JsonKey(defaultValue: {})
   late Map<String, String> defaultAccounts;
 
+  /// Account used for anonymous instances, refers to an actorId
+  @JsonKey(defaultValue: null)
+  late String? anonymousAccount;
+
   /// default account for the app
   /// It is in a form of `username@instanceHost`
   @protected

--- a/lib/stores/accounts_store.dart
+++ b/lib/stores/accounts_store.dart
@@ -28,7 +28,13 @@ class AccountsStore extends ChangeNotifier {
   @JsonKey(defaultValue: {})
   late Map<String, String> defaultAccounts;
 
-  /// Account used for anonymous instances, refers to an actorId
+  /// Instance used for anonymous instances, refers to an instanceHost
+  @protected
+  @JsonKey(defaultValue: null)
+  late String? anonymousAccountInstance;
+
+  /// Account used for anonymous instances, refers to a username
+  @protected
   @JsonKey(defaultValue: null)
   late String? anonymousAccount;
 
@@ -170,6 +176,33 @@ class AccountsStore extends ChangeNotifier {
     }
 
     return accounts[instanceHost]!.isEmpty;
+  }
+
+  /// Checks whether the given user is the anonymous user.
+  bool isAnonymousUser(String instanceHost, String username) {
+    return anonymousAccountInstance == instanceHost && anonymousAccount == username;
+  }
+
+  Future<void> setAnonymousAccount(String instanceHost, String username) {
+    // These have to exist.
+    accounts[instanceHost]![username]!;
+    
+    anonymousAccountInstance = instanceHost;
+    anonymousAccount = username;
+    return save();
+  }
+
+  Future<void> removeAnonymousAccount() {
+    anonymousAccountInstance = null;
+    anonymousAccount = null;
+    return save();
+  }
+
+  /// Checks if there as an anonymous user for the given instance. In the
+  /// future, I might add the ability to assign anonymous users to different
+  /// instances to get around federation. Or not, we'll see.
+  bool hasAnonymousUserFor(String instanceHost) {
+    return anonymousAccount != null;
   }
 
   /// `true` if no added instance has an account assigned to it

--- a/lib/stores/accounts_store.g.dart
+++ b/lib/stores/accounts_store.g.dart
@@ -22,6 +22,7 @@ AccountsStore _$AccountsStoreFromJson(Map<String, dynamic> json) =>
                 (k, e) => MapEntry(k, e as String),
               ) ??
               {}
+      ..anonymousAccountInstance = json['anonymousAccountInstance'] as String?
       ..anonymousAccount = json['anonymousAccount'] as String?
       ..defaultAccount = json['defaultAccount'] as String?;
 
@@ -29,6 +30,7 @@ Map<String, dynamic> _$AccountsStoreToJson(AccountsStore instance) =>
     <String, dynamic>{
       'accounts': instance.accounts,
       'defaultAccounts': instance.defaultAccounts,
+      'anonymousAccountInstance': instance.anonymousAccountInstance,
       'anonymousAccount': instance.anonymousAccount,
       'defaultAccount': instance.defaultAccount,
     };

--- a/lib/stores/accounts_store.g.dart
+++ b/lib/stores/accounts_store.g.dart
@@ -22,12 +22,14 @@ AccountsStore _$AccountsStoreFromJson(Map<String, dynamic> json) =>
                 (k, e) => MapEntry(k, e as String),
               ) ??
               {}
+      ..anonymousAccount = json['anonymousAccount'] as String?
       ..defaultAccount = json['defaultAccount'] as String?;
 
 Map<String, dynamic> _$AccountsStoreToJson(AccountsStore instance) =>
     <String, dynamic>{
       'accounts': instance.accounts,
       'defaultAccounts': instance.defaultAccounts,
+      'anonymousAccount': instance.anonymousAccount,
       'defaultAccount': instance.defaultAccount,
     };
 

--- a/lib/widgets/comment/comment_actions.dart
+++ b/lib/widgets/comment/comment_actions.dart
@@ -22,6 +22,12 @@ class CommentActions extends HookWidget {
         (store) => store.comment.instanceHost,
       ),
     );
+    final anonymousLoggedInAction = useLoggedInAction(
+      context.select<CommentStore, String>(
+        (store) => store.comment.instanceHost,
+      ),
+      allowAnonymous: true,
+    );
 
     return ObserverBuilder<CommentStore>(
       builder: (context, store) {
@@ -88,7 +94,7 @@ class CommentActions extends HookWidget {
             if (!comment.deleted && !comment.removed && !post.locked)
               TileAction(
                 icon: Icons.reply,
-                onPressed: loggedInAction((_) => reply()),
+                onPressed: anonymousLoggedInAction((_) => reply()),
                 tooltip: L10n.of(context).reply,
               ),
             TileAction(

--- a/lib/widgets/write_comment.dart
+++ b/lib/widgets/write_comment.dart
@@ -34,7 +34,8 @@ class WriteComment extends HookWidget {
   Widget build(BuildContext context) {
     final showFancy = useState(false);
     final delayed = useDelayedLoading();
-    final loggedInAction = useLoggedInAction(post.instanceHost, allowAnonymous: true);
+    final loggedInAction =
+        useLoggedInAction(post.instanceHost, allowAnonymous: true);
 
     final editorController = useEditorController(
       instanceHost: post.instanceHost,
@@ -82,7 +83,8 @@ class WriteComment extends HookWidget {
 
               if (comment != null) {
                 // Resolve just the parent comment.
-                final response = await originApi.run(ResolveObject(q: comment!.apId, auth: token.raw ));
+                final response = await originApi
+                    .run(ResolveObject(q: comment!.apId, auth: token.raw));
 
                 return originApi.run(CreateComment(
                   content: editorController.textEditingController.text,
@@ -92,7 +94,8 @@ class WriteComment extends HookWidget {
                 ));
               } else {
                 // Resolve the main post.
-                final response = await originApi.run(ResolveObject(q: post.apId, auth: token.raw ));
+                final response = await originApi
+                    .run(ResolveObject(q: post.apId, auth: token.raw));
 
                 return originApi.run(CreateComment(
                   content: editorController.textEditingController.text,


### PR DESCRIPTION
Hello everyone! I'm creating this WIP PR for the implementation of something that I've wanted to implement in various ways since I first heard about Lemmy: the ability to browse an instance, but post from your home instance. I'm pushing this as early as now so that we can all be collaborative with the implementation of this.

# What Does it Do?
This allows you to have one account, but still participate in the other instances through it without subscribing. I'm more of an "All" scroller, and if you run your own instance you probably have noticed a lot of the time your "All" page is not as lively as the big instances since you have to be subscribed from your instance. This has been a big cause of confusion and annoyance since people have been migrating from Reddit, since the way to do that via browser isn't very straightforward.

To implement this, I've added a new setting called "Use this account for anonymous instances" in the settings:

![image](https://github.com/liftoff-app/liftoff/assets/1340627/06fade2d-f4fe-4b8b-9a23-8b6740bd100c)

This will make that account the account which is used for interacting with any instance where you're not logged in. You can only have one of these, though.

![image](https://github.com/liftoff-app/liftoff/assets/1340627/ba68015e-1d1b-4622-9c16-6406b332183f)

Perhaps in the future that will change. I have some plumbing in there that could make it possible.

## What's Implemented
So far, for a proof of concept, I've only implemented one thing: writing comments. You can reply to posts and comments in other instances. It's a little bit janky right now because the comment that's returned is the comment on your home instance, but you're looking at posts which are on other instances.

# How Does it Work?
Internally, when you try to interact with posts on instances where you don't have an added account, the app will run a `ResolveObject` call first on your main instance to retrieve the post/comment that you're trying to interact with. Then, it will send the request to your instance instead of the instance you're interacting with.

## Does it Federate?
Mostly. I've done some basic testing to see what things do federate. Of course, if you are subscribed to a community it will federate. But if you aren't:

- Comments you make are always federated, and so are comment replies (so your home instance will still see when people reply to your post), but other comments in the post will not be federated back, only direct replies to your comment
- Comment votes are only federated one way, host -> origin -> subscribers (host refers to the instance the comment link came from, origin refers to the instance the comment is actually on, subscribers are the other instances that have a user subscribed to that community)
- Post votes also only federate one way, host -> origin -> subscribers, so your home instance's version of a post will not be updated with additional votes later on
- Posts are always federated in the same way comments are