### PR TITLE
Fix issues with theming

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -23,12 +23,10 @@ class MyApp extends StatelessWidget {
               supportedLocales: L10n.supportedLocales,
               localizationsDelegates: L10n.localizationsDelegates,
               themeMode: state.theme,
-              darkTheme: state.amoled
-                  ? themeFactory(
-                      primaryColor: state.primaryColor,
-                      dark: true,
-                      amoled: true)
-                  : themeFactory(primaryColor: state.primaryColor, dark: true),
+              darkTheme: themeFactory(
+                  primaryColor: state.primaryColor,
+                  amoled: state.amoled,
+                  dark: true),
               locale: context.read<ConfigStore>().locale,
               theme: themeFactory(primaryColor: state.primaryColor),
               home: const HomePage(),

--- a/lib/resources/app_theme.dart
+++ b/lib/resources/app_theme.dart
@@ -7,9 +7,9 @@ class AppTheme extends ChangeNotifier {
   final String primaryKey = 'primary';
 
   SharedPreferences? _prefs;
-  late bool _amoled;
-  late ThemeMode _theme;
-  late Color _primaryColor;
+  bool _amoled = false;
+  ThemeMode _theme = ThemeMode.dark;
+  Color _primaryColor = ThemeData().primaryColorDark;
 
   bool get amoled => _amoled;
   ThemeMode get theme => _theme;

--- a/lib/resources/app_theme.dart
+++ b/lib/resources/app_theme.dart
@@ -9,7 +9,7 @@ class AppTheme extends ChangeNotifier {
   SharedPreferences? _prefs;
   bool _amoled = false;
   ThemeMode _theme = ThemeMode.dark;
-  Color _primaryColor = ThemeData().primaryColorDark;
+  Color _primaryColor = ThemeData().colorScheme.secondary;
 
   bool get amoled => _amoled;
   ThemeMode get theme => _theme;
@@ -51,8 +51,8 @@ class AppTheme extends ChangeNotifier {
     _amoled = _prefs?.getBool(amoledKey) ?? false;
 
     final defaultPrimary = _theme == ThemeMode.light
-        ? ThemeData().primaryColorLight
-        : ThemeData().primaryColorDark;
+        ? ThemeData.light().colorScheme.primary
+        : ThemeData.dark().colorScheme.secondary;
     _primaryColor = Color(_prefs?.getInt(primaryKey) ?? defaultPrimary.value);
 
     notifyListeners();

--- a/lib/resources/theme.dart
+++ b/lib/resources/theme.dart
@@ -94,10 +94,6 @@ ThemeData themeFactory(
         borderRadius: BorderRadius.circular(10),
       ),
     ),
-    floatingActionButtonTheme: FloatingActionButtonThemeData(
-      backgroundColor: primaryColor,
-      foregroundColor: theme.colorScheme.onSurface,
-    ),
     colorScheme: theme.colorScheme.copyWith(
       primary: primaryColor,
       secondary: primaryColor,

--- a/lib/resources/theme.dart
+++ b/lib/resources/theme.dart
@@ -7,13 +7,8 @@ ThemeData themeFactory(
     {bool dark = false, bool amoled = false, required Color primaryColor}) {
   assert(dark || !amoled, "Can't have amoled without dark mode");
 
-  var theme = dark ? ThemeData.dark() : ThemeData.light();
+  final theme = dark ? ThemeData.dark() : ThemeData.light();
   final maybeAmoledColor = amoled ? Colors.black : null;
-
-  theme = theme.copyWith(
-    colorScheme: theme.colorScheme
-        .copyWith(primary: primaryColor, secondary: primaryColor),
-  );
 
   return theme.copyWith(
     pageTransitionsTheme: const PageTransitionsTheme(
@@ -45,17 +40,17 @@ ThemeData themeFactory(
     tabBarTheme: TabBarTheme(
       unselectedLabelColor: Colors.grey,
       labelColor: theme.colorScheme.onSurface,
-      indicatorColor: theme.colorScheme.primary,
+      indicatorColor: primaryColor,
     ),
     chipTheme: ChipThemeData(
-      backgroundColor: theme.colorScheme.secondary,
+      backgroundColor: primaryColor,
       disabledColor: Colors.amber,
       selectedColor: Colors.amber,
       secondarySelectedColor: Colors.amber,
       padding: EdgeInsets.zero,
       shape: const StadiumBorder(),
       labelStyle: TextStyle(
-        color: textColorBasedOnBackground(theme.colorScheme.secondary),
+        color: textColorBasedOnBackground(primaryColor),
       ),
       secondaryLabelStyle: const TextStyle(color: Colors.amber),
       brightness: theme.brightness,
@@ -100,8 +95,12 @@ ThemeData themeFactory(
       ),
     ),
     floatingActionButtonTheme: FloatingActionButtonThemeData(
-      backgroundColor: theme.colorScheme.secondary,
+      backgroundColor: primaryColor,
       foregroundColor: theme.colorScheme.onSurface,
+    ),
+    colorScheme: theme.colorScheme.copyWith(
+      primary: primaryColor,
+      secondary: primaryColor,
     ),
   );
 }


### PR DESCRIPTION
_amoled, _theme, and _primaryColor in app_theme.dart are accessed before they're initialized. This is because the ChangeNotififierProvider in app.dart renders immediately after AppTheme() is instantiated, but the initialization of these fields is done asynchronously since it has to retrieve them from saved preferences. To fix this, I added default values to the variables. I got the default of _primaryColor from where it was being reset in settings.dart.

Additionally, there was definitely something wrong with the usage of the primary color passed in from AppTheme. It wasn't respecting the primaryColor passed from AppTheme, in fact if you look at the actual values of these colors primaryColorLight and primaryColorDark are just lighter and darker version of the flutter default blue color, not the blue/green versions you'd expect. I've updated these to reflect accordingly. But then switching from dark to light and back completely ignores this value and just makes the primary color green. I've fixed this as well by using the value directly where it was being taken from the colorScheme, and also applying it as the primary and secondary colors in the color scheme.