### PR TITLE
fixed markdown parsing of lemmy links

### DIFF
--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -25,6 +25,24 @@ Future<void> linkLauncher({
 
   final instances = context.read<AccountsStore>().instances;
 
+  // CHECK IF EMAIL STYLE LINK TO COMMUNITY
+  // Format: !liftoff@lemmy.world
+  if (url.startsWith('!')) {
+    final splitCommunityName = url.replaceAll(RegExp('!'), '').split('@');
+    await Navigator.of(context).push(CommunityPage.fromNameRoute(
+        splitCommunityName[1], splitCommunityName[0]));
+    return;
+  }
+
+  // CHECK IF EMAIL STYLE LINK TO USER
+  // Format: @user@lemmy.world
+  if (url.startsWith('@')) {
+    final usernameSplit = url.replaceFirst(RegExp('@'), '').split('@');
+    push(() => UserPage.fromName(
+        instanceHost: usernameSplit[1], username: usernameSplit[0]));
+    return;
+  }
+
   final chonks = url.split('/');
   if (chonks.length == 1) {
     await launchLink(link: url, context: context);

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -5,7 +5,6 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:markdown/markdown.dart' as md;
 
 import '../url_launcher.dart';
-import '../util/cleanup_url.dart';
 import 'cached_network_image.dart';
 import 'fullscreenable_image.dart';
 

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -16,12 +16,12 @@ import 'fullscreenable_image.dart';
 /// /u/username@server.com
 /// @username@server.com
 
-class CommunityLinkSyntax extends md.InlineSyntax {
+class LemmyLinkSyntax extends md.InlineSyntax {
   // https://github.com/LemmyNet/lemmy-ui/blob/61255bf01a8d2acdbb77229838002bf8067ada70/src/shared/config.ts#L38
   static const String _pattern =
       r'(\/[cmu]\/|@|!)([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})';
 
-  CommunityLinkSyntax() : super(_pattern);
+  LemmyLinkSyntax() : super(_pattern);
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {
@@ -69,7 +69,7 @@ class MarkdownText extends StatelessWidget {
             // TODO: use a font from google fonts maybe? the defaults aren't very pretty
             ?.copyWith(fontFamily: Platform.isIOS ? 'Courier' : 'monospace'),
       ),
-      inlineSyntaxes: [CommunityLinkSyntax()],
+      inlineSyntaxes: [LemmyLinkSyntax()],
       onTapLink: (text, href, title) {
         if (href == null) return;
         linkLauncher(context: context, url: href, instanceHost: instanceHost)

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -5,8 +5,37 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:markdown/markdown.dart' as md;
 
 import '../url_launcher.dart';
+import '../util/cleanup_url.dart';
 import 'cached_network_image.dart';
 import 'fullscreenable_image.dart';
+
+/// Accepted formats:
+/// !community@server.com
+/// /c/community@server.com
+/// /m/community@server.com
+/// /u/username@server.com
+/// @username@server.com
+
+class CommunityLinkSyntax extends md.InlineSyntax {
+  // https://github.com/LemmyNet/lemmy-ui/blob/61255bf01a8d2acdbb77229838002bf8067ada70/src/shared/config.ts#L38
+  static const String _pattern =
+      r'(\/[cmu]\/|@|!)([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})';
+
+  CommunityLinkSyntax() : super(_pattern);
+
+  @override
+  bool onMatch(md.InlineParser parser, Match match) {
+    final modifier = match[1]!;
+    final name = match[2]!;
+    final url = match[3]!;
+    final anchor = md.Element.text('a', '$modifier$name@$url');
+
+    anchor.attributes['href'] = '$modifier$name@$url';
+    parser.addNode(anchor);
+
+    return true;
+  }
+}
 
 /// A Markdown renderer with link/image handling
 class MarkdownText extends StatelessWidget {
@@ -40,6 +69,7 @@ class MarkdownText extends StatelessWidget {
             // TODO: use a font from google fonts maybe? the defaults aren't very pretty
             ?.copyWith(fontFamily: Platform.isIOS ? 'Courier' : 'monospace'),
       ),
+      inlineSyntaxes: [CommunityLinkSyntax()],
       onTapLink: (text, href, title) {
         if (href == null) return;
         linkLauncher(context: context, url: href, instanceHost: instanceHost)


### PR DESCRIPTION
Fixed the link parsing of lemmy related links within markdown:

![image](https://github.com/liftoff-app/liftoff/assets/6200670/c3900aad-62a1-497b-b3eb-35cab32aa47b)


These links all resolve as expected and navigate the user to the proper page within Liftoff.

Comment for testing:  https://lemmy.world/comment/701823
