### PR TITLE
Add ability to block community from post menu

### DIFF
--- a/lib/widgets/post/post_more_menu.dart
+++ b/lib/widgets/post/post_more_menu.dart
@@ -149,6 +149,17 @@ class PostMoreMenu extends HookWidget {
                       },
                     );
                   },
+                )
+              else
+                ListTile(
+                  leading: store.communityBlockingState.isLoading
+                      ? const CircularProgressIndicator.adaptive()
+                      : const Icon(Icons.block),
+                  title: const Text('Block community'),
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    loggedInAction(store.blockCommunity)();
+                  },
                 ),
               ListTile(
                 leading: const Icon(Icons.translate),

--- a/lib/widgets/post/post_store.dart
+++ b/lib/widgets/post/post_store.dart
@@ -15,6 +15,7 @@ abstract class _PostStore with Store {
   final votingState = AsyncStore<PostView>();
   final savingState = AsyncStore<PostView>();
   final userBlockingState = AsyncStore<BlockedPerson>();
+  final communityBlockingState = AsyncStore<BlockedCommunity>();
   final reportingState = AsyncStore<PostReportView>();
   final deletingState = AsyncStore<PostView>();
 
@@ -101,6 +102,16 @@ abstract class _PostStore with Store {
     if (result != null) {
       postView = postView.copyWith(creatorBlocked: result.blocked);
     }
+  }
+
+  @action
+  Future<void> blockCommunity(UserData userData) async {
+    await communityBlockingState.runLemmy(
+        postView.post.instanceHost,
+        BlockCommunity(
+            communityId: postView.community.id,
+            block: true,
+            auth: userData.jwt.raw));
   }
 
   @action


### PR DESCRIPTION
Fixes #32 

A couple of things to note. I didn't add in the `unblock/block` logic that user blocking has as the fact that a community is blocked is not readily available from the present records. I didn't want to add another call just to check the community status. Getting to a post is also pretty hard if you have blocked a community. Even your comments disappear from your profile when you have blocked the whole community.

I wasn't able to figure out how to trigger a refresh of the infinite list if someone blocks a community. The posts will stick around until they refresh. This is also the current behaviour when you unblock a community from the settings. You still need to manually refresh the list to start seeing the posts again.

Let me know if there is a way to trigger a refresh of the list and I can add in the functionality.

Cheers!