### PR TITLE
Translate function added

### DIFF
--- a/lib/widgets/comment/comment_more_menu_button.dart
+++ b/lib/widgets/comment/comment_more_menu_button.dart
@@ -89,6 +89,9 @@ class _CommentMoreMenuPopup extends HookWidget {
         final targetRect = Rect.fromPoints(position,
             position.translate(renderbox.size.width, renderbox.size.height));
 
+        final targetLanguage = Localizations.localeOf(context).languageCode;
+        final sourceText = Uri.encodeComponent(comment.content);
+
         return Column(
           children: [
             ListTile(
@@ -121,6 +124,18 @@ class _CommentMoreMenuPopup extends HookWidget {
                   sharePositionOrigin: targetRect,
                   context: context,
                 );
+                Navigator.of(context).pop();
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.translate),
+              title: const Text('Translate'),
+              onTap: () async {
+                await launchLink(
+                    link:
+                        'https://translate.google.com/?tl=$targetLanguage&text=$sourceText',
+                    context: context);
+
                 Navigator.of(context).pop();
               },
             ),

--- a/lib/widgets/post/post_more_menu.dart
+++ b/lib/widgets/post/post_more_menu.dart
@@ -69,6 +69,10 @@ class PostMoreMenu extends HookWidget {
         builder: (context, store) {
           final post = store.postView;
 
+          final targetLanguage = Localizations.localeOf(context).languageCode;
+          final sourceText = Uri.encodeComponent(
+              '${post.post.name}\n---\n${post.post.body ?? ""}');
+
           return Column(
             children: [
               ListTile(
@@ -135,6 +139,18 @@ class PostMoreMenu extends HookWidget {
                     );
                   },
                 ),
+              ListTile(
+                leading: const Icon(Icons.translate),
+                title: const Text('Translate'),
+                onTap: () async {
+                  await launchLink(
+                      link:
+                          'https://translate.google.com/?tl=$targetLanguage&text=$sourceText',
+                      context: context);
+
+                  Navigator.of(context).pop();
+                },
+              ),
               ListTile(
                 leading: store.reportingState.isLoading
                     ? const CircularProgressIndicator.adaptive()


### PR DESCRIPTION
Uses web browser to call google translate page directly, so no API issues. User is prompted to login on first use but can scroll down and choose not to do so and refuse cookies.