### PR TITLE
Trim username string when adding account

### DIFF
--- a/lib/pages/settings/add_account_page.dart
+++ b/lib/pages/settings/add_account_page.dart
@@ -160,7 +160,12 @@ class AddAccountPage extends HookWidget {
                 AutofillHints.email,
                 AutofillHints.username
               ],
-              onSubmitted: (_) => passwordFocusNode.requestFocus(),
+              onTapOutside: (_) =>
+                  usernameController.text = usernameController.text.trim(),
+              onSubmitted: (_) {
+                usernameController.text = usernameController.text.trim();
+                passwordFocusNode.requestFocus();
+              },
               decoration: InputDecoration(
                   labelText: L10n.of(context).email_or_username),
             ),


### PR DESCRIPTION
Trim() the username string upon submission or text field losing focus, fixes #233