### PR TITLE
Add Chrome Custom Tabs/Safari View Controller (replace internal browser)

### DIFF
--- a/lib/pages/settings/settings.dart
+++ b/lib/pages/settings/settings.dart
@@ -465,10 +465,10 @@ class GeneralConfigPage extends StatelessWidget {
               },
             ),
             SwitchListTile.adaptive(
-              title: const Text('Use in-app browser'),
-              value: store.useInAppBrowser,
+              title: const Text('Use external browser'),
+              value: !store.useInAppBrowser,
               onChanged: (checked) {
-                store.useInAppBrowser = checked;
+                store.useInAppBrowser = !checked;
               },
             ),
             const SizedBox(height: 12),

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -44,8 +44,10 @@ Future<void> _launchCustomTab(BuildContext context, String link) async {
       ),
     );
   } catch (e) {
-    // An exception is thrown if browser app is not installed on Android device.
-    debugPrint(e.toString());
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(e.toString())));
+    await ul.launchUrl(Uri.parse(link),
+        mode: ul.LaunchMode.externalApplication);
   }
 }
 

--- a/lib/url_launcher.dart
+++ b/lib/url_launcher.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:logging/logging.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart' as ul;
@@ -11,6 +14,40 @@ import 'pages/user.dart';
 import 'stores/accounts_store.dart';
 import 'stores/config_store.dart';
 import 'util/goto.dart';
+import 'util/text_color.dart';
+
+///Launches a Chrome Custom Tab on Android or Safari View Controller on iOS
+Future<void> _launchCustomTab(BuildContext context, String link) async {
+  try {
+    await launch(
+      link,
+      customTabsOption: CustomTabsOption(
+        toolbarColor: Theme.of(context).colorScheme.primary,
+        enableDefaultShare: true,
+        enableUrlBarHiding: true,
+        showPageTitle: true,
+        animation: CustomTabsSystemAnimation.slideIn(),
+        extraCustomTabs: const <String>[
+          // ref. https://play.google.com/store/apps/details?id=org.mozilla.firefox
+          'org.mozilla.firefox',
+          // ref. https://play.google.com/store/apps/details?id=com.microsoft.emmx
+          'com.microsoft.emmx',
+        ],
+      ),
+      safariVCOption: SafariViewControllerOption(
+        preferredBarTintColor: Theme.of(context).colorScheme.primary,
+        preferredControlTintColor:
+            textColorBasedOnBackground(Theme.of(context).colorScheme.primary),
+        barCollapsingEnabled: true,
+        entersReaderIfAvailable: false,
+        dismissButtonStyle: SafariViewControllerDismissButtonStyle.close,
+      ),
+    );
+  } catch (e) {
+    // An exception is thrown if browser app is not installed on Android device.
+    debugPrint(e.toString());
+  }
+}
 
 /// Decides where does a link link to. Either somewhere in-app:
 /// opens the correct page, or outside of the app: opens in a browser
@@ -133,10 +170,18 @@ Future<bool> launchLink({
 }) async {
   final uri = Uri.tryParse(link);
   if (uri != null) {
-    await ul.launchUrl(uri,
-        mode: context.read<ConfigStore>().useInAppBrowser
-            ? ul.LaunchMode.platformDefault
-            : ul.LaunchMode.externalApplication);
+    if (Platform.isAndroid || Platform.isIOS) {
+      if (context.read<ConfigStore>().useInAppBrowser) {
+        await _launchCustomTab(context, link);
+      } else {
+        await ul.launchUrl(uri, mode: ul.LaunchMode.externalApplication);
+      }
+    } else {
+      await ul.launchUrl(uri,
+          mode: context.read<ConfigStore>().useInAppBrowser
+              ? ul.LaunchMode.platformDefault
+              : ul.LaunchMode.externalApplication);
+    }
     return true;
   } else {
     _logger.warning('Failed to launch a link: $link');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -318,6 +318,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  flutter_custom_tabs:
+    dependency: "direct main"
+    description:
+      name: flutter_custom_tabs
+      sha256: bebb9552438eb3aea8f8511d48e41abdd0d05ff3e9a74622a4d1acd2bffd242c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
+  flutter_custom_tabs_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_custom_tabs_platform_interface
+      sha256: bbd2d9a2ff22d27e079a35302ddd3da9f2328110c370d56c81655a7ba306fee2
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  flutter_custom_tabs_web:
+    dependency: transitive
+    description:
+      name: flutter_custom_tabs_web
+      sha256: d735abff9a1b215018dfe2584f131fe0a3bb0e3b685fbd6ae8a55cf5c4d7dcd8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_hooks:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ dependencies:
   flutter_colorpicker: ^1.0.3
   path_provider: ^2.0.15
   path: ^1.8.3
+  flutter_custom_tabs: ^1.0.4
 
 # https://github.com/flutter/flutter/issues/127425
 dependency_overrides:


### PR DESCRIPTION
I didn't love the in-app view we had been using, so I added Chrome Custom Tabs for Android and Safari View Controller for iOS. This should maintain compatibility across OS's through conditional statements, but testing is welcome.

I also changed the nomenclature for the settings page to be "Use external browser:" and flipped the logic because they're both external in a way.