### PR TITLE
fix: Use FadeTransition for full screen media opacity

### DIFF
--- a/lib/util/goto.dart
+++ b/lib/util/goto.dart
@@ -76,20 +76,16 @@ void goToMedia(BuildContext context, String url, String heroTag) {
     PageRouteBuilder(
       pageBuilder: (_, __, ___) => MediaViewPage(url, heroTag: heroTag),
       opaque: false,
-      transitionsBuilder: (_, animation, __, child) =>
-          TweenAnimationBuilder<double>(
-        duration: Duration(
-          milliseconds: store.disableAnimations ? 1 : 200,
-        ),
-        tween: Tween<double>(begin: 0, end: 1),
-        builder: (_, value, child) {
-          return Opacity(
-            opacity: value,
-            child: child,
-          );
-        },
-        child: child,
+      transitionDuration: Duration(
+        milliseconds: store.disableAnimations ? 1 : 200,
       ),
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        final curve = CurveTween(curve: Curves.easeOut);
+        return FadeTransition(
+          opacity: animation.drive(curve),
+          child: child,
+        );
+      },
     ),
   );
 }


### PR DESCRIPTION
This PR is a follow up to https://github.com/liftoff-app/liftoff/pull/219#issuecomment-1616685657, where we indicated a desire to resolve a broken animation when backing out of a `MediaViewPage`.

To achieve this, the previous `TweenAnimationBuilder` was removed in favor of `FadeTransition`. This transition achieves the same effect in less code and can be driven backwards when the animation is reversed on pop.

https://github.com/liftoff-app/liftoff/assets/459941/18afb664-bf0a-440d-9b6a-62131f99cbea

