### PR TITLE
Auto-hide "not logged in" snackbar

### DIFF
--- a/lib/hooks/logged_in_action.dart
+++ b/lib/hooks/logged_in_action.dart
@@ -46,6 +46,7 @@ VoidCallback Function(
     if (store.isAnonymousFor(instanceHost)) {
       return () {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          duration: const Duration(seconds: 7),
           content: Text(message ??
               'This thread was retrieved via $instanceHost.\nYou are not logged in there.'),
           action: SnackBarAction(


### PR DESCRIPTION
Auto-hides the "You're not logged in, log in" snackbar after 7 seconds.

This Snackbar is displayed attempting to interact (post a comment, upvote, downvote, etc) with an instance you're not logged into. The current behavior is to display it indefinitely, and the Snackbar never disappears on its own, you MUST click "log in" to make it disappear.