### PR TITLE
Menu item to view a community in a specific instance other than the originating instance

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -154,6 +154,10 @@
   "@pinned": {},
   "by": "by",
   "@by": {},
+  "view_on": "View on another instance",
+  "@view_on": {},
+  "foreign_community_info": "Loading the community in the other instance. Note that if this is the first time the community is being viewed in the instance, this process may take a while.",
+  "@foreign_community_info": {},
 
   "error": "Error: {error_text}",
   "@error" :{

--- a/lib/hooks/logged_in_action.dart
+++ b/lib/hooks/logged_in_action.dart
@@ -39,12 +39,16 @@ VoidCallback Function(
 VoidCallback Function(
   void Function(UserData userData) action, [
   String? message,
-]) useLoggedInAction(String instanceHost) {
+]) useLoggedInAction(String instanceHost, {void Function()? fallback}) {
   final context = useContext();
   final store = useAccountsStore();
 
   return (action, [message]) {
     if (store.isAnonymousFor(instanceHost)) {
+      if (fallback != null && !store.hasNoAccount) {
+        return fallback;
+      }
+
       return () {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           duration: const Duration(seconds: 7),

--- a/lib/hooks/logged_in_action.dart
+++ b/lib/hooks/logged_in_action.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:lemmy_api_client/v3.dart';
 
 import '../pages/settings/settings.dart';
+import '../stores/accounts_store.dart';
 import '../util/goto.dart';
 import 'stores.dart';
 
@@ -36,7 +37,7 @@ VoidCallback Function(
 }
 
 VoidCallback Function(
-  void Function(Jwt token) action, [
+  void Function(UserData userData) action, [
   String? message,
 ]) useLoggedInAction(String instanceHost) {
   final context = useContext();
@@ -55,7 +56,7 @@ VoidCallback Function(
         ));
       };
     }
-    final token = store.defaultUserDataFor(instanceHost)!.jwt;
-    return () => action(token);
+    final userData = store.defaultUserDataFor(instanceHost)!;
+    return () => action(userData);
   };
 }

--- a/lib/pages/communities_tab.dart
+++ b/lib/pages/communities_tab.dart
@@ -10,6 +10,7 @@ import '../hooks/delayed_loading.dart';
 import '../hooks/logged_in_action.dart';
 import '../hooks/refreshable.dart';
 import '../hooks/stores.dart';
+import '../stores/accounts_store.dart';
 import '../util/extensions/api.dart';
 import '../util/extensions/iterators.dart';
 import '../util/goto.dart';
@@ -256,14 +257,14 @@ class _CommunitySubscribeToggle extends HookWidget {
     final delayed = useDelayedLoading();
     final loggedInAction = useLoggedInAction(instanceHost);
 
-    handleTap(Jwt token) async {
+    handleTap(UserData userData) async {
       delayed.start();
 
       try {
         await LemmyApiV3(instanceHost).run(FollowCommunity(
           communityId: communityId,
           follow: !subbed.value,
-          auth: token.raw,
+          auth: userData.jwt.raw,
         ));
         subbed.value = !subbed.value;
       } on Exception catch (err) {

--- a/lib/pages/community/community.dart
+++ b/lib/pages/community/community.dart
@@ -61,8 +61,7 @@ class CommunityPage extends HookWidget {
                     ? FailedToLoad(
                         refresh: () => store.refresh(context
                             .read<AccountsStore>()
-                            .defaultUserDataFor(store.instanceHost)
-                            ?.jwt),
+                            .defaultUserDataFor(store.instanceHost)),
                         message: communityState.errorTerm!.tr(context),
                       )
                     : const CircularProgressIndicator.adaptive()),
@@ -166,10 +165,8 @@ class CommunityPage extends HookWidget {
       builder: (context) {
         return MobxProvider.value(
           value: store
-            ..refresh(context
-                .read<AccountsStore>()
-                .defaultUserDataFor(instanceHost)
-                ?.jwt),
+            ..refresh(
+                context.read<AccountsStore>().defaultUserDataFor(instanceHost)),
           child: const CommunityPage(),
         );
       },

--- a/lib/pages/community/community_about_tab.dart
+++ b/lib/pages/community/community_about_tab.dart
@@ -27,8 +27,7 @@ class CommmunityAboutTab extends StatelessWidget {
       onRefresh: () async {
         await context.read<CommunityStore>().refresh(context
             .read<AccountsStore>()
-            .defaultUserDataFor(fullCommunityView.instanceHost)
-            ?.jwt);
+            .defaultUserDataFor(fullCommunityView.instanceHost));
       },
       child: ListView(
         padding: const EdgeInsets.only(top: 20),

--- a/lib/pages/community/community_follow_button.dart
+++ b/lib/pages/community/community_follow_button.dart
@@ -5,6 +5,7 @@ import 'package:lemmy_api_client/v3.dart';
 import '../../hooks/logged_in_action.dart';
 import '../../l10n/l10n.dart';
 import '../../util/observer_consumers.dart';
+import '../view_on_menu.dart';
 import 'community_store.dart';
 
 class CommunityFollowButton extends HookWidget {
@@ -16,8 +17,10 @@ class CommunityFollowButton extends HookWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final loggedInAction =
-        useLoggedInAction(context.read<CommunityStore>().instanceHost);
+    final loggedInAction = useLoggedInAction(
+        context.read<CommunityStore>().instanceHost, fallback: () {
+      ViewOnMenu.openForCommunity(context, communityView);
+    });
 
     return ObserverBuilder<CommunityStore>(builder: (context, store) {
       return ElevatedButtonTheme(

--- a/lib/pages/community/community_more_menu.dart
+++ b/lib/pages/community/community_more_menu.dart
@@ -42,8 +42,8 @@ class CommunityMoreMenu extends HookWidget {
                 '${fullCommunityView.communityView.blocked ? L10n.of(context).unblock : L10n.of(context).block} ${communityView.community.preferredName}'),
             onTap: store.blockingState.isLoading
                 ? null
-                : loggedInAction((token) {
-                    store.block(token);
+                : loggedInAction((userData) {
+                    store.block(userData);
                     Navigator.of(context).pop();
                   }),
           );

--- a/lib/pages/community/community_more_menu.dart
+++ b/lib/pages/community/community_more_menu.dart
@@ -1,16 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import '../../hooks/logged_in_action.dart';
 import '../../l10n/l10n.dart';
+import '../../stores/accounts_store.dart';
 import '../../url_launcher.dart';
 import '../../util/extensions/api.dart';
 import '../../util/mobx_provider.dart';
 import '../../util/observer_consumers.dart';
 import '../../widgets/bottom_modal.dart';
 import '../../widgets/info_table_popup.dart';
+import '../view_on_menu.dart';
 import 'community_store.dart';
+import 'foreign_community.dart';
 
 class CommunityMoreMenu extends HookWidget {
   final FullCommunityView fullCommunityView;
@@ -32,6 +36,11 @@ class CommunityMoreMenu extends HookWidget {
             link: communityView.community.actorId,
             context: context,
           ),
+        ),
+        ListTile(
+          leading: const Icon(Icons.travel_explore),
+          title: Text(L10n.of(context).view_on),
+          onTap: () => ViewOnMenu.openForCommunity(context, communityView),
         ),
         ObserverBuilder<CommunityStore>(builder: (context, store) {
           return ListTile(

--- a/lib/pages/community/community_more_menu.dart
+++ b/lib/pages/community/community_more_menu.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:lemmy_api_client/v3.dart';
-import 'package:swipeable_page_route/swipeable_page_route.dart';
 
 import '../../hooks/logged_in_action.dart';
 import '../../l10n/l10n.dart';
-import '../../stores/accounts_store.dart';
 import '../../url_launcher.dart';
 import '../../util/extensions/api.dart';
 import '../../util/mobx_provider.dart';
@@ -14,7 +12,6 @@ import '../../widgets/bottom_modal.dart';
 import '../../widgets/info_table_popup.dart';
 import '../view_on_menu.dart';
 import 'community_store.dart';
-import 'foreign_community.dart';
 
 class CommunityMoreMenu extends HookWidget {
   final FullCommunityView fullCommunityView;

--- a/lib/pages/community/community_overview.dart
+++ b/lib/pages/community/community_overview.dart
@@ -108,7 +108,7 @@ class CommunityOverview extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 20),
                 child: Text(
-                  community.community.title,
+                  '${community.community.title}${community.community.instanceHost != community.community.originInstanceHost ? ' (via ${community.community.instanceHost})' : ''}',
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     fontWeight: FontWeight.w300,

--- a/lib/pages/community/community_store.dart
+++ b/lib/pages/community/community_store.dart
@@ -1,6 +1,7 @@
 import 'package:lemmy_api_client/v3.dart';
 import 'package:mobx/mobx.dart';
 
+import '../../stores/accounts_store.dart';
 import '../../util/async_store.dart';
 
 part 'community_store.g.dart';
@@ -26,11 +27,11 @@ abstract class _CommunityStore with Store {
   final blockingState = AsyncStore<BlockedCommunity>();
 
   @action
-  Future<void> refresh(Jwt? token) async {
+  Future<void> refresh(UserData? userData) async {
     await communityState.runLemmy(
       instanceHost,
       GetCommunity(
-        auth: token?.raw,
+        auth: userData?.jwt.raw,
         id: id,
         name: communityName,
       ),
@@ -38,7 +39,7 @@ abstract class _CommunityStore with Store {
     );
   }
 
-  Future<void> block(Jwt token) async {
+  Future<void> block(UserData userData) async {
     final state = communityState.asyncState;
     if (state is! AsyncStateData<FullCommunityView>) {
       throw StateError('communityState should be ready at this point');
@@ -49,7 +50,7 @@ abstract class _CommunityStore with Store {
       BlockCommunity(
         communityId: state.data.communityView.community.id,
         block: !state.data.communityView.blocked,
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
 
@@ -60,7 +61,7 @@ abstract class _CommunityStore with Store {
   }
 
   @action
-  Future<void> subscribe(Jwt token) async {
+  Future<void> subscribe(UserData userData) async {
     final state = communityState.asyncState;
 
     if (state is! AsyncStateData<FullCommunityView>) {
@@ -81,7 +82,7 @@ abstract class _CommunityStore with Store {
             return true;
           }
         }(),
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
 

--- a/lib/pages/community/community_store.g.dart
+++ b/lib/pages/community/community_store.g.dart
@@ -13,16 +13,16 @@ mixin _$CommunityStore on _CommunityStore, Store {
       AsyncAction('_CommunityStore.refresh', context: context);
 
   @override
-  Future<void> refresh(Jwt? token) {
-    return _$refreshAsyncAction.run(() => super.refresh(token));
+  Future<void> refresh(UserData? userData) {
+    return _$refreshAsyncAction.run(() => super.refresh(userData));
   }
 
   late final _$subscribeAsyncAction =
       AsyncAction('_CommunityStore.subscribe', context: context);
 
   @override
-  Future<void> subscribe(Jwt token) {
-    return _$subscribeAsyncAction.run(() => super.subscribe(token));
+  Future<void> subscribe(UserData userData) {
+    return _$subscribeAsyncAction.run(() => super.subscribe(userData));
   }
 
   @override

--- a/lib/pages/community/federated_community.dart
+++ b/lib/pages/community/federated_community.dart
@@ -6,11 +6,11 @@ import '../../l10n/l10n.dart';
 import '../../stores/accounts_store.dart';
 import 'community.dart';
 
-class ForeignCommunityPage extends HookWidget {
+class FederatedCommunityPage extends HookWidget {
   final UserData userData;
   final String community;
 
-  const ForeignCommunityPage(this.userData, this.community);
+  const FederatedCommunityPage(this.userData, this.community);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/community/foreign_community.dart
+++ b/lib/pages/community/foreign_community.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:lemmy_api_client/v3.dart';
+
+import '../../l10n/l10n.dart';
+import '../../stores/accounts_store.dart';
+import 'community.dart';
+
+class ForeignCommunityPage extends HookWidget {
+  final UserData userData;
+  final String community;
+
+  const ForeignCommunityPage(this.userData, this.community);
+
+  @override
+  Widget build(BuildContext context) {
+    final lemmyApi = LemmyApiV3(userData.instanceHost);
+
+    return FutureBuilder(
+      future: lemmyApi
+          .run(ResolveObject(q: community, auth: userData.jwt.raw))
+          .then((data) {
+        Navigator.of(context).pop();
+        Navigator.of(context).push(CommunityPage.fromIdRoute(
+            userData.instanceHost, data.community!.community.id));
+      }),
+      builder: (context, snapshot) {
+        return Scaffold(
+            appBar: AppBar(),
+            body: Container(
+                padding: const EdgeInsets.all(10),
+                child: Column(
+                  children: [
+                    Container(height: 36),
+                    const Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        CircularProgressIndicator(),
+                      ],
+                    ),
+                    Container(height: 24),
+                    Text(
+                      snapshot.hasError
+                          ? 'Error: ${snapshot.error}'
+                          : L10n.of(context).foreign_community_info,
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                )));
+      },
+    );
+  }
+}

--- a/lib/pages/create_post/create_post.dart
+++ b/lib/pages/create_post/create_post.dart
@@ -35,9 +35,9 @@ class CreatePostPage extends HookWidget {
         text: context.read<CreatePostStore>().body);
     final titleFocusNode = useFocusNode();
 
-    handleSubmit(Jwt token) async {
+    handleSubmit(UserData userData) async {
       if (formKey.currentState!.validate()) {
-        await context.read<CreatePostStore>().submit(token);
+        await context.read<CreatePostStore>().submit(userData);
       }
     }
 

--- a/lib/pages/create_post/create_post_community_picker.dart
+++ b/lib/pages/create_post/create_post_community_picker.dart
@@ -60,7 +60,7 @@ class CreatePostCommunityPicker extends HookWidget {
             suggestionsCallback: (pattern) async {
               final communities = await store.searchCommunities(
                 pattern,
-                context.defaultJwt(store.instanceHost),
+                context.defaultUserData(store.instanceHost),
               );
 
               return communities ?? [];

--- a/lib/pages/create_post/create_post_store.dart
+++ b/lib/pages/create_post/create_post_store.dart
@@ -2,6 +2,7 @@ import 'package:lemmy_api_client/pictrs.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:mobx/mobx.dart';
 
+import '../../stores/accounts_store.dart';
 import '../../util/async_store.dart';
 import '../../util/pictrs.dart';
 
@@ -52,7 +53,7 @@ abstract class _CreatePostStore with Store {
   @action
   Future<List<CommunityView>?> searchCommunities(
     String searchTerm,
-    Jwt? token,
+    UserData? userData,
   ) {
     if (searchTerm.isEmpty) {
       return searchCommunitiesState.runLemmy(
@@ -61,7 +62,7 @@ abstract class _CreatePostStore with Store {
           type: PostListingType.all,
           sort: SortType.topAll,
           limit: 10,
-          auth: token?.raw,
+          auth: userData?.jwt.raw,
         ),
       );
     } else {
@@ -72,14 +73,14 @@ abstract class _CreatePostStore with Store {
           sort: SortType.topAll,
           listingType: PostListingType.all,
           limit: 10,
-          auth: token?.raw,
+          auth: userData?.jwt.raw,
         ),
       );
     }
   }
 
   @action
-  Future<void> submit(Jwt token) async {
+  Future<void> submit(UserData token) async {
     await submitState.runLemmy(
       instanceHost,
       isEdit
@@ -89,7 +90,7 @@ abstract class _CreatePostStore with Store {
               nsfw: nsfw,
               name: title,
               postId: postToEdit!.id,
-              auth: token.raw,
+              auth: token.jwt.raw,
             )
           : CreatePost(
               url: url.isEmpty ? null : url,
@@ -97,20 +98,20 @@ abstract class _CreatePostStore with Store {
               nsfw: nsfw,
               name: title,
               communityId: selectedCommunity!.community.id,
-              auth: token.raw,
+              auth: token.jwt.raw,
             ),
     );
   }
 
   @action
-  Future<void> uploadImage(String filePath, Jwt token) async {
+  Future<void> uploadImage(String filePath, UserData userData) async {
     final instanceHost = this.instanceHost;
 
     final upload = await imageUploadState.run(
       () => PictrsApi(instanceHost)
           .upload(
             filePath: filePath,
-            auth: token.raw,
+            auth: userData.jwt.raw,
           )
           .then((value) => value.files.single),
     );

--- a/lib/pages/create_post/create_post_store.g.dart
+++ b/lib/pages/create_post/create_post_store.g.dart
@@ -130,7 +130,7 @@ mixin _$CreatePostStore on _CreatePostStore, Store {
       AsyncAction('_CreatePostStore.submit', context: context);
 
   @override
-  Future<void> submit(Jwt token) {
+  Future<void> submit(UserData token) {
     return _$submitAsyncAction.run(() => super.submit(token));
   }
 
@@ -138,9 +138,9 @@ mixin _$CreatePostStore on _CreatePostStore, Store {
       AsyncAction('_CreatePostStore.uploadImage', context: context);
 
   @override
-  Future<void> uploadImage(String filePath, Jwt token) {
+  Future<void> uploadImage(String filePath, UserData userData) {
     return _$uploadImageAsyncAction
-        .run(() => super.uploadImage(filePath, token));
+        .run(() => super.uploadImage(filePath, userData));
   }
 
   late final _$_CreatePostStoreActionController =
@@ -148,11 +148,11 @@ mixin _$CreatePostStore on _CreatePostStore, Store {
 
   @override
   Future<List<CommunityView>?> searchCommunities(
-      String searchTerm, Jwt? token) {
+      String searchTerm, UserData? userData) {
     final _$actionInfo = _$_CreatePostStoreActionController.startAction(
         name: '_CreatePostStore.searchCommunities');
     try {
-      return super.searchCommunities(searchTerm, token);
+      return super.searchCommunities(searchTerm, userData);
     } finally {
       _$_CreatePostStoreActionController.endAction(_$actionInfo);
     }

--- a/lib/pages/create_post/create_post_url_field.dart
+++ b/lib/pages/create_post/create_post_url_field.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:lemmy_api_client/v3.dart';
 
 import '../../hooks/logged_in_action.dart';
 import '../../hooks/stores.dart';
 import '../../l10n/l10n.dart';
+import '../../stores/accounts_store.dart';
 import '../../util/files.dart';
 import '../../util/observer_consumers.dart';
 import 'create_post_store.dart';
@@ -23,12 +23,12 @@ class CreatePostUrlField extends HookWidget {
       useStore((CreatePostStore store) => store.instanceHost),
     );
 
-    uploadImage(Jwt token) async {
+    uploadImage(UserData userData) async {
       final pic = await pickImage();
 
       // pic is null when the picker was cancelled
       if (pic != null) {
-        await context.read<CreatePostStore>().uploadImage(pic.path, token);
+        await context.read<CreatePostStore>().uploadImage(pic.path, userData);
       }
     }
 

--- a/lib/pages/full_post/comment_section.dart
+++ b/lib/pages/full_post/comment_section.dart
@@ -26,8 +26,7 @@ class CommentSection {
                     '${store.fullPostState.errorTerm}',
                 refresh: () => store.refresh(context
                     .read<AccountsStore>()
-                    .defaultUserDataFor(store.instanceHost)
-                    ?.jwt)),
+                    .defaultUserDataFor(store.instanceHost))),
           )
         ];
       } else {

--- a/lib/pages/full_post/full_post.dart
+++ b/lib/pages/full_post/full_post.dart
@@ -57,8 +57,7 @@ class FullPostPage extends HookWidget {
           Future<void> refresh() async {
             await store.refresh(context
                 .read<AccountsStore>()
-                .defaultUserDataFor(store.instanceHost)
-                ?.jwt);
+                .defaultUserDataFor(store.instanceHost));
           }
 
           final postStore = store.postStore;
@@ -181,15 +180,15 @@ class FullPostPage extends HookWidget {
     );
   }
 
-  static Jwt? _tryGetJwt(BuildContext context, String instanceHost) {
-    return context.read<AccountsStore>().defaultUserDataFor(instanceHost)?.jwt;
+  static UserData? _tryGetUserData(BuildContext context, String instanceHost) {
+    return context.read<AccountsStore>().defaultUserDataFor(instanceHost);
   }
 
   static Route route(int id, String instanceHost) => SwipeablePageRoute(
         builder: (context) => MobxProvider(
           create: (context) =>
               FullPostStore(instanceHost: instanceHost, postId: id)
-                ..refresh(_tryGetJwt(context, instanceHost)),
+                ..refresh(_tryGetUserData(context, instanceHost)),
           child: const FullPostPage._(),
         ),
       );
@@ -197,14 +196,15 @@ class FullPostPage extends HookWidget {
   static Route fromPostViewRoute(PostView postView) => SwipeablePageRoute(
         builder: (context) => MobxProvider(
           create: (context) => FullPostStore.fromPostView(postView)
-            ..refresh(_tryGetJwt(context, postView.instanceHost)),
+            ..refresh(_tryGetUserData(context, postView.instanceHost)),
           child: const FullPostPage._(),
         ),
       );
   static Route fromPostStoreRoute(PostStore postStore) => SwipeablePageRoute(
         builder: (context) => MobxProvider(
           create: (context) => FullPostStore.fromPostStore(postStore)
-            ..refresh(_tryGetJwt(context, postStore.postView.instanceHost)),
+            ..refresh(
+                _tryGetUserData(context, postStore.postView.instanceHost)),
           child: const FullPostPage._(),
         ),
       );

--- a/lib/pages/full_post/full_post_store.dart
+++ b/lib/pages/full_post/full_post_store.dart
@@ -3,6 +3,7 @@ import 'package:mobx/mobx.dart';
 
 import '../../comment_tree.dart';
 import '../../hooks/stores.dart';
+import '../../stores/accounts_store.dart';
 import '../../stores/config_store.dart';
 import '../../util/async_store.dart';
 import '../../widgets/post/post_store.dart';
@@ -79,9 +80,9 @@ abstract class _FullPostStore with Store {
   Iterable<CommentView>? get comments => postComments?.followedBy(newComments);
 
   @action
-  Future<void> refresh([Jwt? token]) async {
+  Future<void> refresh([UserData? userData]) async {
     final result = await fullPostState.runLemmy(
-        instanceHost, GetPost(id: postId, auth: token?.raw));
+        instanceHost, GetPost(id: postId, auth: userData?.jwt.raw));
 
     final commentsResult = await commentsState.runLemmy(
         instanceHost,
@@ -104,13 +105,13 @@ abstract class _FullPostStore with Store {
   }
 
   @action
-  Future<void> blockCommunity(Jwt token) async {
+  Future<void> blockCommunity(UserData userData) async {
     final result = await communityBlockingState.runLemmy(
         instanceHost,
         BlockCommunity(
             communityId: fullPostView!.communityView.community.id,
             block: !fullPostView!.communityView.blocked,
-            auth: token.raw));
+            auth: userData.jwt.raw));
     if (result != null) {
       fullPostView =
           fullPostView!.copyWith(communityView: result.communityView);

--- a/lib/pages/full_post/full_post_store.g.dart
+++ b/lib/pages/full_post/full_post_store.g.dart
@@ -138,16 +138,17 @@ mixin _$FullPostStore on _FullPostStore, Store {
       AsyncAction('_FullPostStore.refresh', context: context);
 
   @override
-  Future<void> refresh([Jwt? token]) {
-    return _$refreshAsyncAction.run(() => super.refresh(token));
+  Future<void> refresh([UserData? userData]) {
+    return _$refreshAsyncAction.run(() => super.refresh(userData));
   }
 
   late final _$blockCommunityAsyncAction =
       AsyncAction('_FullPostStore.blockCommunity', context: context);
 
   @override
-  Future<void> blockCommunity(Jwt token) {
-    return _$blockCommunityAsyncAction.run(() => super.blockCommunity(token));
+  Future<void> blockCommunity(UserData userData) {
+    return _$blockCommunityAsyncAction
+        .run(() => super.blockCommunity(userData));
   }
 
   late final _$_FullPostStoreActionController =

--- a/lib/pages/instance/instance.dart
+++ b/lib/pages/instance/instance.dart
@@ -42,7 +42,7 @@ class InstancePage extends HookWidget {
             body: Center(
               child: FailedToLoad(
                 refresh: () => store.fetch(
-                  context.defaultJwt(store.instanceHost),
+                  context.defaultUserData(store.instanceHost),
                 ),
                 message: errorTerm.tr(context),
               ),
@@ -162,7 +162,10 @@ class InstancePage extends HookWidget {
                           limit: batchSize,
                           page: page,
                           savedOnly: false,
-                          auth: context.defaultJwt(store.instanceHost)?.raw,
+                          auth: context
+                              .defaultUserData(store.instanceHost)
+                              ?.jwt
+                              .raw,
                         )),
                       ),
                       InfiniteCommentList(
@@ -173,7 +176,10 @@ class InstancePage extends HookWidget {
                           limit: batchSize,
                           page: page,
                           savedOnly: false,
-                          auth: context.defaultJwt(store.instanceHost)?.raw,
+                          auth: context
+                              .defaultUserData(store.instanceHost)
+                              ?.jwt
+                              .raw,
                         )),
                       ),
                       InstanceAboutTab(
@@ -196,7 +202,7 @@ class InstancePage extends HookWidget {
       builder: (context) {
         return MobxProvider(
           create: (context) => InstanceStore(instanceHost)
-            ..fetch(context.defaultJwt(instanceHost)),
+            ..fetch(context.defaultUserData(instanceHost)),
           child: const InstancePage(),
         );
       },

--- a/lib/pages/instance/instance_about_tab.dart
+++ b/lib/pages/instance/instance_about_tab.dart
@@ -39,7 +39,7 @@ class InstanceAboutTab extends HookWidget {
               sort: sortType,
               limit: batchSize,
               page: page,
-              auth: context.defaultJwt(site.instanceHost)?.raw,
+              auth: context.defaultUserData(site.instanceHost)?.jwt.raw,
             ),
           ),
           title: l10n.communities_of_instance(siteView.site.name),
@@ -50,7 +50,7 @@ class InstanceAboutTab extends HookWidget {
     return PullToRefresh(
       onRefresh: () => context
           .read<InstanceStore>()
-          .fetch(context.defaultJwt(site.instanceHost), refresh: true),
+          .fetch(context.defaultUserData(site.instanceHost), refresh: true),
       child: SingleChildScrollView(
         child: SafeArea(
           top: false,
@@ -142,7 +142,7 @@ class InstanceAboutTab extends HookWidget {
                   ),
                   error: (errorTerm) => FailedToLoad(
                     refresh: () => store.fetchCommunites(
-                        context.defaultJwt(store.instanceHost)),
+                        context.defaultUserData(store.instanceHost)),
                     message: errorTerm.tr(context),
                   ),
                   data: (communities) => Column(

--- a/lib/pages/instance/instance_store.dart
+++ b/lib/pages/instance/instance_store.dart
@@ -1,6 +1,7 @@
 import 'package:lemmy_api_client/v3.dart';
 import 'package:mobx/mobx.dart';
 
+import '../../stores/accounts_store.dart';
 import '../../util/async_store.dart';
 
 part 'instance_store.g.dart';
@@ -16,26 +17,27 @@ abstract class _InstanceStore with Store {
   final communitiesState = AsyncStore<List<CommunityView>>();
 
   @action
-  Future<void> fetch(Jwt? token, {bool refresh = false}) async {
+  Future<void> fetch(UserData? userData, {bool refresh = false}) async {
     await Future.wait([
       siteState.runLemmy(
         instanceHost,
-        GetSite(auth: token?.raw),
+        GetSite(auth: userData?.jwt.raw),
         refresh: refresh,
       ),
-      fetchCommunites(token, refresh: refresh),
+      fetchCommunites(userData, refresh: refresh),
     ]);
   }
 
   @action
-  Future<void> fetchCommunites(Jwt? token, {bool refresh = false}) async {
+  Future<void> fetchCommunites(UserData? userData,
+      {bool refresh = false}) async {
     await communitiesState.runLemmy(
       instanceHost,
       ListCommunities(
         type: PostListingType.local,
         sort: SortType.hot,
         limit: 6,
-        auth: token?.raw,
+        auth: userData?.jwt.raw,
       ),
       refresh: refresh,
     );

--- a/lib/pages/instance/instance_store.g.dart
+++ b/lib/pages/instance/instance_store.g.dart
@@ -13,17 +13,18 @@ mixin _$InstanceStore on _InstanceStore, Store {
       AsyncAction('_InstanceStore.fetch', context: context);
 
   @override
-  Future<void> fetch(Jwt? token, {bool refresh = false}) {
-    return _$fetchAsyncAction.run(() => super.fetch(token, refresh: refresh));
+  Future<void> fetch(UserData? userData, {bool refresh = false}) {
+    return _$fetchAsyncAction
+        .run(() => super.fetch(userData, refresh: refresh));
   }
 
   late final _$fetchCommunitesAsyncAction =
       AsyncAction('_InstanceStore.fetchCommunites', context: context);
 
   @override
-  Future<void> fetchCommunites(Jwt? token, {bool refresh = false}) {
+  Future<void> fetchCommunites(UserData? userData, {bool refresh = false}) {
     return _$fetchCommunitesAsyncAction
-        .run(() => super.fetchCommunites(token, refresh: refresh));
+        .run(() => super.fetchCommunites(userData, refresh: refresh));
   }
 
   @override

--- a/lib/pages/settings/blocks/blocks.dart
+++ b/lib/pages/settings/blocks/blocks.dart
@@ -142,12 +142,13 @@ class _UserBlocks extends HookWidget {
                     onTap: store.userBlockingState.isLoading
                         ? null
                         : loggedInAction(
-                            (token) async {
+                            (userData) async {
                               final person =
                                   await BlockPersonDialog.show(context);
 
                               if (person != null) {
-                                await store.blockUser(token, person.person.id);
+                                await store.blockUser(
+                                    userData, person.person.id);
                               }
                             },
                           ),
@@ -176,13 +177,13 @@ class _UserBlocks extends HookWidget {
                     onTap: store.communityBlockingState.isLoading
                         ? null
                         : loggedInAction(
-                            (token) async {
+                            (userData) async {
                               final community =
                                   await BlockCommunityDialog.show(context);
 
                               if (community != null) {
                                 await store.blockCommunity(
-                                  token,
+                                  userData,
                                   community.community.id,
                                 );
                               }

--- a/lib/pages/settings/blocks/blocks_store.dart
+++ b/lib/pages/settings/blocks/blocks_store.dart
@@ -1,6 +1,7 @@
 import 'package:lemmy_api_client/v3.dart';
 import 'package:mobx/mobx.dart';
 
+import '../../../stores/accounts_store.dart';
 import '../../../util/async_store.dart';
 import 'community_block_store.dart';
 import 'user_block_store.dart';
@@ -38,7 +39,7 @@ abstract class _BlocksStore with Store {
   bool get isUsable => blockedUsers != null && blockedCommunities != null;
 
   @action
-  Future<void> blockUser(Jwt token, int id) async {
+  Future<void> blockUser(UserData userData, int id) async {
     if (_blockedUsers == null) {
       throw StateError("_blockedUsers can't be null at this moment");
     }
@@ -47,7 +48,7 @@ abstract class _BlocksStore with Store {
       BlockPerson(
         personId: id,
         block: true,
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
 
@@ -57,14 +58,14 @@ abstract class _BlocksStore with Store {
         UserBlockStore(
           instanceHost: instanceHost,
           person: res.personView.person,
-          token: token,
+          token: userData.jwt,
         ),
       );
     }
   }
 
   @action
-  Future<void> blockCommunity(Jwt token, int id) async {
+  Future<void> blockCommunity(UserData userData, int id) async {
     if (_blockedCommunities == null) {
       throw StateError("_blockedCommunities can't be null at this moment");
     }
@@ -73,7 +74,7 @@ abstract class _BlocksStore with Store {
       BlockCommunity(
         communityId: id,
         block: true,
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
 
@@ -83,7 +84,7 @@ abstract class _BlocksStore with Store {
         CommunityBlockStore(
           instanceHost: instanceHost,
           community: res.communityView.community,
-          token: token,
+          token: userData.jwt,
         ),
       );
     }

--- a/lib/pages/settings/blocks/blocks_store.g.dart
+++ b/lib/pages/settings/blocks/blocks_store.g.dart
@@ -68,17 +68,17 @@ mixin _$BlocksStore on _BlocksStore, Store {
       AsyncAction('_BlocksStore.blockUser', context: context);
 
   @override
-  Future<void> blockUser(Jwt token, int id) {
-    return _$blockUserAsyncAction.run(() => super.blockUser(token, id));
+  Future<void> blockUser(UserData userData, int id) {
+    return _$blockUserAsyncAction.run(() => super.blockUser(userData, id));
   }
 
   late final _$blockCommunityAsyncAction =
       AsyncAction('_BlocksStore.blockCommunity', context: context);
 
   @override
-  Future<void> blockCommunity(Jwt token, int id) {
+  Future<void> blockCommunity(UserData userData, int id) {
     return _$blockCommunityAsyncAction
-        .run(() => super.blockCommunity(token, id));
+        .run(() => super.blockCommunity(userData, id));
   }
 
   late final _$refreshAsyncAction =

--- a/lib/pages/view_on_menu.dart
+++ b/lib/pages/view_on_menu.dart
@@ -3,15 +3,15 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:lemmy_api_client/v3.dart';
 import 'package:swipeable_page_route/swipeable_page_route.dart';
 
-import '../l10n/l10n.dart';
-import './community/community_store.dart';
 import '../hooks/memo_future.dart';
 import '../hooks/stores.dart';
+import '../l10n/l10n.dart';
 import '../stores/accounts_store.dart';
 import '../util/mobx_provider.dart';
 import '../util/observer_consumers.dart';
 import '../widgets/bottom_modal.dart';
 import '../widgets/cached_network_image.dart';
+import 'community/community_store.dart';
 import 'community/federated_community.dart';
 
 class ViewOnMenu extends HookWidget {

--- a/lib/pages/view_on_menu.dart
+++ b/lib/pages/view_on_menu.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:lemmy_api_client/v3.dart';
+import 'package:swipeable_page_route/swipeable_page_route.dart';
+
+import '../l10n/l10n.dart';
+import './community/community_store.dart';
+import '../hooks/memo_future.dart';
+import '../hooks/stores.dart';
+import '../stores/accounts_store.dart';
+import '../util/mobx_provider.dart';
+import '../util/observer_consumers.dart';
+import '../widgets/bottom_modal.dart';
+import '../widgets/cached_network_image.dart';
+import 'community/foreign_community.dart';
+
+class ViewOnMenu extends HookWidget {
+  final void Function(UserData userData) onSelect;
+
+  const ViewOnMenu({super.key, required this.onSelect});
+
+  @override
+  Widget build(BuildContext context) {
+    final accountsStore = useAccountsStore();
+    final theme = Theme.of(context);
+    final instancesIcons = useMemoFuture(() async {
+      final sites = await Future.wait(accountsStore.instances.map((e) =>
+          LemmyApiV3(e)
+              .run<FullSiteView?>(const GetSite())
+              .catchError((e) => null)));
+
+      return {
+        for (final site in sites)
+          if (site != null) site.instanceHost: site.siteView?.site.icon
+      };
+    });
+
+    return Column(children: [
+      ListTile(
+          title: Text(
+        L10n.of(context).view_on,
+        style: const TextStyle(fontWeight: FontWeight.bold),
+      )),
+      for (final instance in accountsStore.loggedInInstances) ...[
+        ListTile(
+          title: Text(
+            instance.toUpperCase(),
+            style: TextStyle(
+                color: theme.textTheme.bodyLarge?.color?.withOpacity(0.7)),
+          ),
+          dense: true,
+          contentPadding: EdgeInsets.zero,
+          visualDensity:
+              const VisualDensity(vertical: VisualDensity.minimumDensity),
+          leading:
+              (instancesIcons.hasData && instancesIcons.data![instance] != null)
+                  ? Padding(
+                      padding: const EdgeInsets.only(left: 20),
+                      child: SizedBox(
+                        width: 25,
+                        height: 25,
+                        child: CachedNetworkImage(
+                          imageUrl: instancesIcons.data![instance]!,
+                          height: 25,
+                          width: 25,
+                        ),
+                      ),
+                    )
+                  : const SizedBox(width: 30),
+        ),
+        for (final account in accountsStore.allUserDataFor(instance)) ...[
+          ListTile(
+            title: Text('${account.username}@$instance'),
+            onTap: () => onSelect(account),
+            leading: const SizedBox(width: 20),
+          ),
+        ]
+      ],
+    ]);
+  }
+
+  static void open(
+      BuildContext context, void Function(UserData userData) onSelect) {
+    final store = context.read<CommunityStore>();
+
+    showBottomModal(
+      context: context,
+      builder: (context) => MobxProvider.value(
+        value: store,
+        child: ViewOnMenu(
+          onSelect: onSelect,
+        ),
+      ),
+    );
+  }
+
+  static void openForCommunity(
+      BuildContext context, CommunityView communityView) {
+    ViewOnMenu.open(context, (UserData userData) {
+      Navigator.of(context).push(SwipeablePageRoute(
+          builder: (context) =>
+              ForeignCommunityPage(userData, communityView.community.actorId)));
+    });
+  }
+}

--- a/lib/pages/view_on_menu.dart
+++ b/lib/pages/view_on_menu.dart
@@ -12,7 +12,7 @@ import '../util/mobx_provider.dart';
 import '../util/observer_consumers.dart';
 import '../widgets/bottom_modal.dart';
 import '../widgets/cached_network_image.dart';
-import 'community/foreign_community.dart';
+import 'community/federated_community.dart';
 
 class ViewOnMenu extends HookWidget {
   final void Function(UserData userData) onSelect;
@@ -98,8 +98,8 @@ class ViewOnMenu extends HookWidget {
       BuildContext context, CommunityView communityView) {
     ViewOnMenu.open(context, (UserData userData) {
       Navigator.of(context).push(SwipeablePageRoute(
-          builder: (context) =>
-              ForeignCommunityPage(userData, communityView.community.actorId)));
+          builder: (context) => FederatedCommunityPage(
+              userData, communityView.community.actorId)));
     });
   }
 }

--- a/lib/pages/write_message.dart
+++ b/lib/pages/write_message.dart
@@ -4,6 +4,7 @@ import 'package:lemmy_api_client/v3.dart';
 
 import '../hooks/logged_in_action.dart';
 import '../l10n/l10n.dart';
+import '../stores/accounts_store.dart';
 import '../util/extensions/api.dart';
 import '../widgets/markdown_mode_icon.dart';
 import '../widgets/markdown_text.dart';
@@ -40,12 +41,12 @@ class WriteMessagePage extends HookWidget {
     final submit = _isEdit ? L10n.of(context).save : 'send';
     final title = _isEdit ? 'Edit message' : L10n.of(context).send_message;
 
-    handleSubmit(Jwt token) async {
+    handleSubmit(UserData userData) async {
       if (_isEdit) {
         loading.value = true;
         try {
           final msg = await LemmyApiV3(instanceHost).run(EditPrivateMessage(
-            auth: token.raw,
+            auth: userData.jwt.raw,
             privateMessageId: privateMessage!.id,
             content: bodyController.text,
           ));
@@ -60,7 +61,7 @@ class WriteMessagePage extends HookWidget {
         loading.value = true;
         try {
           await LemmyApiV3(instanceHost).run(CreatePrivateMessage(
-            auth: token.raw,
+            auth: userData.jwt.raw,
             content: bodyController.text,
             recipientId: recipient.id,
           ));

--- a/lib/stores/accounts_store.dart
+++ b/lib/stores/accounts_store.dart
@@ -36,9 +36,26 @@ class AccountsStore extends ChangeNotifier {
   static Future<AccountsStore> load() async {
     final prefs = await _prefs;
 
-    return _$AccountsStoreFromJson(
-      jsonDecode(prefs.getString(prefsKey) ?? '{}') as Map<String, dynamic>,
-    );
+    // Migrate old accounts store which didn't store instanceHost or username.
+    final accountsStoreJson =
+        jsonDecode(prefs.getString(prefsKey) ?? '{}') as Map<String, dynamic>;
+
+    if (accountsStoreJson.containsKey('accounts')) {
+      final accountsJson =
+          accountsStoreJson['accounts'] as Map<String, dynamic>;
+
+      for (final instanceEntry in accountsJson.entries) {
+        for (final accountEntry in instanceEntry.value.entries) {
+          if (!accountEntry.value.containsKey('instanceHost') ||
+              !accountEntry.value.containsKey('username')) {
+            accountEntry.value['instanceHost'] = instanceEntry.key;
+            accountEntry.value['username'] = accountEntry.key;
+          }
+        }
+      }
+    }
+
+    return _$AccountsStoreFromJson(accountsStoreJson);
   }
 
   Future<void> save() async {
@@ -217,6 +234,8 @@ class AccountsStore extends ChangeNotifier {
     accounts[instanceHost]![userData.name] = UserData(
       jwt: jwt,
       userId: userData.id,
+      instanceHost: instanceHost,
+      username: userData.name,
     );
 
     await _assignDefaultAccounts();
@@ -277,10 +296,14 @@ class AccountsStore extends ChangeNotifier {
 class UserData {
   final Jwt jwt;
   final int userId;
+  final String username;
+  final String instanceHost;
 
   const UserData({
     required this.jwt,
     required this.userId,
+    required this.username,
+    required this.instanceHost,
   });
 
   factory UserData.fromJson(Map<String, dynamic> json) =>

--- a/lib/stores/accounts_store.dart
+++ b/lib/stores/accounts_store.dart
@@ -151,6 +151,18 @@ class AccountsStore extends ChangeNotifier {
     return accounts[instanceHost]?[username];
   }
 
+  List<UserData> allUserDataFor(String instanceHost) {
+    if (!accounts.containsKey(instanceHost)) {
+      return [];
+    }
+
+    return [
+      for (final account in accounts[instanceHost]!.keys) ...[
+        userDataFor(instanceHost, account)!
+      ]
+    ];
+  }
+
   /// sets globally default account
   Future<void> setDefaultAccount(String instanceHost, String username) {
     defaultAccount = '$username@$instanceHost';

--- a/lib/stores/accounts_store.g.dart
+++ b/lib/stores/accounts_store.g.dart
@@ -34,9 +34,13 @@ Map<String, dynamic> _$AccountsStoreToJson(AccountsStore instance) =>
 UserData _$UserDataFromJson(Map<String, dynamic> json) => UserData(
       jwt: Jwt.fromJson(json['jwt'] as String),
       userId: json['userId'] as int,
+      username: json['username'] as String,
+      instanceHost: json['instanceHost'] as String,
     );
 
 Map<String, dynamic> _$UserDataToJson(UserData instance) => <String, dynamic>{
       'jwt': instance.jwt,
       'userId': instance.userId,
+      'username': instance.username,
+      'instanceHost': instance.instanceHost,
     };

--- a/lib/util/extensions/context.dart
+++ b/lib/util/extensions/context.dart
@@ -6,6 +6,6 @@ import '../observer_consumers.dart';
 
 extension BuildContextExtensions on BuildContext {
   /// Get default [Jwt] for an instance
-  Jwt? defaultJwt(String instanceHost) =>
-      read<AccountsStore>().defaultUserDataFor(instanceHost)?.jwt;
+  UserData? defaultUserData(String instanceHost) =>
+      read<AccountsStore>().defaultUserDataFor(instanceHost);
 }

--- a/lib/widgets/comment/comment_more_menu_button.dart
+++ b/lib/widgets/comment/comment_more_menu_button.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:lemmy_api_client/v3.dart';
 
 import '../../hooks/logged_in_action.dart';
 import '../../l10n/l10n.dart';
+import '../../stores/accounts_store.dart';
 import '../../url_launcher.dart';
 import '../../util/extensions/api.dart';
 import '../../util/icons.dart';
@@ -64,8 +64,8 @@ class _CommentMoreMenuPopup extends HookWidget {
         final comment = store.comment.comment;
         final post = store.comment.post;
 
-        handleDelete(Jwt token) {
-          store.delete(token);
+        handleDelete(UserData userData) {
+          store.delete(userData);
           Navigator.of(context).pop();
         }
 
@@ -187,9 +187,9 @@ class _CommentMoreMenuPopup extends HookWidget {
                     : const Icon(Icons.block),
                 title: Text(
                     '${store.comment.creatorBlocked ? L10n.of(context).unblock : L10n.of(context).block} ${store.comment.creator.preferredName}'),
-                onTap: loggedInAction((token) {
+                onTap: loggedInAction((userData) {
                   Navigator.of(context).pop();
-                  store.block(token);
+                  store.block(userData);
                 }),
               ),
             ListTile(
@@ -201,10 +201,10 @@ class _CommentMoreMenuPopup extends HookWidget {
                   ? null
                   : () {
                       Navigator.of(context).pop();
-                      loggedInAction((token) async {
+                      loggedInAction((userData) async {
                         final reason = await ReportDialog.show(context);
                         if (reason != null) {
-                          await store.report(token, reason);
+                          await store.report(userData, reason);
                         }
                       })();
                     },

--- a/lib/widgets/comment/comment_store.dart
+++ b/lib/widgets/comment/comment_store.dart
@@ -79,7 +79,7 @@ abstract class _CommentStore with Store {
   }
 
   @action
-  Future<void> report(Jwt token, String reason) async {
+  Future<void> report(UserData userData, String reason) async {
     if (reason.trim().isEmpty) throw ArgumentError('reason must not be empty');
 
     await reportingState.runLemmy(
@@ -87,19 +87,19 @@ abstract class _CommentStore with Store {
       CreateCommentReport(
         commentId: comment.comment.id,
         reason: reason,
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
   }
 
   @action
-  Future<void> delete(Jwt token) async {
+  Future<void> delete(UserData userData) async {
     final result = await deletingState.runLemmy(
       comment.instanceHost,
       DeleteComment(
         commentId: comment.comment.id,
         deleted: !comment.comment.deleted,
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
 
@@ -107,13 +107,13 @@ abstract class _CommentStore with Store {
   }
 
   @action
-  Future<void> save(Jwt token) async {
+  Future<void> save(UserData userData) async {
     final result = await savingState.runLemmy(
       comment.instanceHost,
       SaveComment(
         commentId: comment.comment.id,
         save: !comment.saved,
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
 
@@ -121,13 +121,13 @@ abstract class _CommentStore with Store {
   }
 
   @action
-  Future<void> block(Jwt token) async {
+  Future<void> block(UserData userData) async {
     final result = await blockingState.runLemmy(
       comment.instanceHost,
       BlockPerson(
         personId: comment.creator.id,
         block: !comment.creatorBlocked,
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
     if (result != null) {
@@ -136,14 +136,14 @@ abstract class _CommentStore with Store {
   }
 
   @action
-  Future<void> markAsRead(Jwt token) async {
+  Future<void> markAsRead(UserData userData) async {
     if (userMentionId != null) {
       final result = await markPersonMentionAsReadState.runLemmy(
         comment.instanceHost,
         MarkPersonMentionAsRead(
           personMentionId: userMentionId!,
           read: !comment.comment.distinguished,
-          auth: token.raw,
+          auth: userData.jwt.raw,
         ),
       );
 
@@ -157,7 +157,7 @@ abstract class _CommentStore with Store {
           MarkCommentAsRead(
             commentReplyId: comment.commentReply!.id,
             read: !comment.comment.distinguished,
-            auth: token.raw,
+            auth: userData.jwt.raw,
           ),
         );
 
@@ -169,13 +169,13 @@ abstract class _CommentStore with Store {
   }
 
   @action
-  Future<void> _vote(VoteType voteType, Jwt token) async {
+  Future<void> _vote(VoteType voteType, UserData userData) async {
     final result = await votingState.runLemmy(
       comment.instanceHost,
       CreateCommentLike(
         commentId: comment.comment.id,
         score: voteType,
-        auth: token.raw,
+        auth: userData.jwt.raw,
       ),
     );
 
@@ -183,18 +183,18 @@ abstract class _CommentStore with Store {
   }
 
   @action
-  Future<void> upVote(Jwt token) async {
+  Future<void> upVote(UserData userData) async {
     await _vote(
       myVote == VoteType.up ? VoteType.none : VoteType.up,
-      token,
+      userData,
     );
   }
 
   @action
-  Future<void> downVote(Jwt token) async {
+  Future<void> downVote(UserData userData) async {
     await _vote(
       myVote == VoteType.down ? VoteType.none : VoteType.down,
-      token,
+      userData,
     );
   }
 

--- a/lib/widgets/comment/comment_store.g.dart
+++ b/lib/widgets/comment/comment_store.g.dart
@@ -96,64 +96,64 @@ mixin _$CommentStore on _CommentStore, Store {
       AsyncAction('_CommentStore.report', context: context);
 
   @override
-  Future<void> report(Jwt token, String reason) {
-    return _$reportAsyncAction.run(() => super.report(token, reason));
+  Future<void> report(UserData userData, String reason) {
+    return _$reportAsyncAction.run(() => super.report(userData, reason));
   }
 
   late final _$deleteAsyncAction =
       AsyncAction('_CommentStore.delete', context: context);
 
   @override
-  Future<void> delete(Jwt token) {
-    return _$deleteAsyncAction.run(() => super.delete(token));
+  Future<void> delete(UserData userData) {
+    return _$deleteAsyncAction.run(() => super.delete(userData));
   }
 
   late final _$saveAsyncAction =
       AsyncAction('_CommentStore.save', context: context);
 
   @override
-  Future<void> save(Jwt token) {
-    return _$saveAsyncAction.run(() => super.save(token));
+  Future<void> save(UserData userData) {
+    return _$saveAsyncAction.run(() => super.save(userData));
   }
 
   late final _$blockAsyncAction =
       AsyncAction('_CommentStore.block', context: context);
 
   @override
-  Future<void> block(Jwt token) {
-    return _$blockAsyncAction.run(() => super.block(token));
+  Future<void> block(UserData userData) {
+    return _$blockAsyncAction.run(() => super.block(userData));
   }
 
   late final _$markAsReadAsyncAction =
       AsyncAction('_CommentStore.markAsRead', context: context);
 
   @override
-  Future<void> markAsRead(Jwt token) {
-    return _$markAsReadAsyncAction.run(() => super.markAsRead(token));
+  Future<void> markAsRead(UserData userData) {
+    return _$markAsReadAsyncAction.run(() => super.markAsRead(userData));
   }
 
   late final _$_voteAsyncAction =
       AsyncAction('_CommentStore._vote', context: context);
 
   @override
-  Future<void> _vote(VoteType voteType, Jwt token) {
-    return _$_voteAsyncAction.run(() => super._vote(voteType, token));
+  Future<void> _vote(VoteType voteType, UserData userData) {
+    return _$_voteAsyncAction.run(() => super._vote(voteType, userData));
   }
 
   late final _$upVoteAsyncAction =
       AsyncAction('_CommentStore.upVote', context: context);
 
   @override
-  Future<void> upVote(Jwt token) {
-    return _$upVoteAsyncAction.run(() => super.upVote(token));
+  Future<void> upVote(UserData userData) {
+    return _$upVoteAsyncAction.run(() => super.upVote(userData));
   }
 
   late final _$downVoteAsyncAction =
       AsyncAction('_CommentStore.downVote', context: context);
 
   @override
-  Future<void> downVote(Jwt token) {
-    return _$downVoteAsyncAction.run(() => super.downVote(token));
+  Future<void> downVote(UserData userData) {
+    return _$downVoteAsyncAction.run(() => super.downVote(userData));
   }
 
   late final _$_CommentStoreActionController =

--- a/lib/widgets/editor/editor_toolbar.dart
+++ b/lib/widgets/editor/editor_toolbar.dart
@@ -150,7 +150,7 @@ class _ToolbarBody extends HookWidget {
         ObserverBuilder<EditorToolbarStore>(
           builder: (context, store) {
             return IconButton(
-              onPressed: loggedInAction((token) async {
+              onPressed: loggedInAction((userData) async {
                 if (store.imageUploadState.isLoading) {
                   return;
                 }
@@ -159,7 +159,7 @@ class _ToolbarBody extends HookWidget {
                   // pic is null when the picker was cancelled
 
                   if (pic != null) {
-                    final picUrl = await store.uploadImage(pic.path, token);
+                    final picUrl = await store.uploadImage(pic.path, userData);
 
                     if (picUrl != null) {
                       controller.reformatSimple('![]($picUrl)');

--- a/lib/widgets/editor/editor_toolbar_store.dart
+++ b/lib/widgets/editor/editor_toolbar_store.dart
@@ -1,7 +1,7 @@
 import 'package:lemmy_api_client/pictrs.dart';
-import 'package:lemmy_api_client/v3.dart';
 import 'package:mobx/mobx.dart';
 
+import '../../stores/accounts_store.dart';
 import '../../util/async_store.dart';
 import '../../util/pictrs.dart';
 
@@ -27,14 +27,14 @@ abstract class _EditorToolbarStore with Store {
       );
 
   @action
-  Future<String?> uploadImage(String filePath, Jwt token) async {
+  Future<String?> uploadImage(String filePath, UserData userData) async {
     final instanceHost = this.instanceHost;
 
     final upload = await imageUploadState.run(
       () => PictrsApi(instanceHost)
           .upload(
             filePath: filePath,
-            auth: token.raw,
+            auth: userData.jwt.raw,
           )
           .then((value) => value.files.single),
     );

--- a/lib/widgets/editor/editor_toolbar_store.g.dart
+++ b/lib/widgets/editor/editor_toolbar_store.g.dart
@@ -37,9 +37,9 @@ mixin _$EditorToolbarStore on _EditorToolbarStore, Store {
       AsyncAction('_EditorToolbarStore.uploadImage', context: context);
 
   @override
-  Future<String?> uploadImage(String filePath, Jwt token) {
+  Future<String?> uploadImage(String filePath, UserData userData) {
     return _$uploadImageAsyncAction
-        .run(() => super.uploadImage(filePath, token));
+        .run(() => super.uploadImage(filePath, userData));
   }
 
   late final _$_EditorToolbarStoreActionController =

--- a/lib/widgets/post/post_store.g.dart
+++ b/lib/widgets/post/post_store.g.dart
@@ -43,40 +43,40 @@ mixin _$PostStore on _PostStore, Store {
       AsyncAction('_PostStore.save', context: context);
 
   @override
-  Future<void> save(Jwt token) {
-    return _$saveAsyncAction.run(() => super.save(token));
+  Future<void> save(UserData userData) {
+    return _$saveAsyncAction.run(() => super.save(userData));
   }
 
   late final _$reportAsyncAction =
       AsyncAction('_PostStore.report', context: context);
 
   @override
-  Future<void> report(Jwt token, String reason) {
-    return _$reportAsyncAction.run(() => super.report(token, reason));
+  Future<void> report(UserData userData, String reason) {
+    return _$reportAsyncAction.run(() => super.report(userData, reason));
   }
 
   late final _$deleteAsyncAction =
       AsyncAction('_PostStore.delete', context: context);
 
   @override
-  Future<void> delete(Jwt token) {
-    return _$deleteAsyncAction.run(() => super.delete(token));
+  Future<void> delete(UserData userData) {
+    return _$deleteAsyncAction.run(() => super.delete(userData));
   }
 
   late final _$blockUserAsyncAction =
       AsyncAction('_PostStore.blockUser', context: context);
 
   @override
-  Future<void> blockUser(Jwt token) {
-    return _$blockUserAsyncAction.run(() => super.blockUser(token));
+  Future<void> blockUser(UserData userData) {
+    return _$blockUserAsyncAction.run(() => super.blockUser(userData));
   }
 
   late final _$_voteAsyncAction =
       AsyncAction('_PostStore._vote', context: context);
 
   @override
-  Future<void> _vote(Jwt token, VoteType voteType) {
-    return _$_voteAsyncAction.run(() => super._vote(token, voteType));
+  Future<void> _vote(UserData userData, VoteType voteType) {
+    return _$_voteAsyncAction.run(() => super._vote(userData, voteType));
   }
 
   late final _$_PostStoreActionController =
@@ -94,22 +94,22 @@ mixin _$PostStore on _PostStore, Store {
   }
 
   @override
-  Future<void> upVote(Jwt token) {
+  Future<void> upVote(UserData userData) {
     final _$actionInfo =
         _$_PostStoreActionController.startAction(name: '_PostStore.upVote');
     try {
-      return super.upVote(token);
+      return super.upVote(userData);
     } finally {
       _$_PostStoreActionController.endAction(_$actionInfo);
     }
   }
 
   @override
-  Future<void> downVote(Jwt token) {
+  Future<void> downVote(UserData userData) {
     final _$actionInfo =
         _$_PostStoreActionController.startAction(name: '_PostStore.downVote');
     try {
-      return super.downVote(token);
+      return super.downVote(userData);
     } finally {
       _$_PostStoreActionController.endAction(_$actionInfo);
     }

--- a/lib/widgets/write_comment.dart
+++ b/lib/widgets/write_comment.dart
@@ -5,6 +5,7 @@ import 'package:lemmy_api_client/v3.dart';
 import '../hooks/delayed_loading.dart';
 import '../hooks/logged_in_action.dart';
 import '../l10n/l10n.dart';
+import '../stores/accounts_store.dart';
 import 'editor/editor.dart';
 import 'markdown_mode_icon.dart';
 import 'markdown_text.dart';
@@ -63,7 +64,7 @@ class WriteComment extends HookWidget {
       );
     }();
 
-    handleSubmit(Jwt token) async {
+    handleSubmit(UserData userData) async {
       final api = LemmyApiV3(post.instanceHost);
 
       delayed.start();
@@ -73,14 +74,14 @@ class WriteComment extends HookWidget {
             return api.run(EditComment(
               commentId: comment!.id,
               content: editorController.textEditingController.text,
-              auth: token.raw,
+              auth: userData.jwt.raw,
             ));
           } else {
             return api.run(CreateComment(
               content: editorController.textEditingController.text,
               postId: post.id,
               parentId: comment?.id,
-              auth: token.raw,
+              auth: userData.jwt.raw,
             ));
           }
         }();


### PR DESCRIPTION
This adds a new menu item which appears under the "..." menu of a community called "View on another instance".
![image](https://github.com/liftoff-app/liftoff/assets/1340627/e7bb7f1a-fd88-444a-b823-1bb5289cb3b8)

This pops up a list of accounts for you to choose from. The "Subscribe" button, when viewing anonymously, also pops this up:
![image](https://github.com/liftoff-app/liftoff/assets/1340627/3a2e257a-d9ac-407f-86df-e4cd3493e0fb)

This then executes a ResolveObject call to retrieve the community:
![image](https://github.com/liftoff-app/liftoff/assets/1340627/9ccd7b96-0aca-4f06-8b04-f8d1b5e69bf9)

Before showing you the community, in the other instance. Denoted by the "(via instance)" text in the name of the community.
![image](https://github.com/liftoff-app/liftoff/assets/1340627/0c8c01d0-0cfd-47cd-8633-29f49ee31ece)

You can then subscribe directly from here, or if some posts are loaded you can even comment or vote directly.

Dependent on #261