### PR TITLE
Add shadow to Bottom App Bar

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -89,21 +89,25 @@ class HomePage extends HookWidget {
       floatingActionButton: Platform.isAndroid ? const CreatePostFab() : null,
       floatingActionButtonLocation:
           Platform.isAndroid ? FloatingActionButtonLocation.centerDocked : null,
-      bottomNavigationBar: BottomAppBar(
-        shape: const CircularNotchedRectangle(),
-        notchMargin: 7,
-        child: SizedBox(
-          height: 60,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              tabButton(Icons.home),
-              tabButton(Icons.list),
-              if (Platform.isAndroid) const SizedBox.shrink(),
-              if (Platform.isAndroid) const SizedBox.shrink(),
-              tabButton(Icons.search),
-              tabButton(Icons.person),
-            ],
+      bottomNavigationBar: Container(
+        decoration: const BoxDecoration(
+            boxShadow: [BoxShadow(color: Colors.black54, blurRadius: 10)]),
+        child: BottomAppBar(
+          shape: const CircularNotchedRectangle(),
+          notchMargin: 7,
+          child: SizedBox(
+            height: 60,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                tabButton(Icons.home),
+                tabButton(Icons.list),
+                if (Platform.isAndroid) const SizedBox.shrink(),
+                if (Platform.isAndroid) const SizedBox.shrink(),
+                tabButton(Icons.search),
+                tabButton(Icons.person),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
This addresses https://github.com/liftoff-app/liftoff/issues/245

This adds some depth so that there's more to visually distinguish it from the cards below.

![Screenshot_20230703_184416](https://github.com/liftoff-app/liftoff/assets/9942801/7295cf75-e2dc-48a4-be48-ef0e23369970)
