### PR TITLE
Comment bugfixes

### DIFF
--- a/lib/pages/full_post/comment_section.dart
+++ b/lib/pages/full_post/comment_section.dart
@@ -14,6 +14,7 @@ class CommentSection {
 
     final fullPostView = store.fullPostView;
     final postComments = store.postComments;
+    final newComments = store.newComments;
 
     // error & spinner handling
     if (fullPostView == null) {
@@ -43,7 +44,7 @@ class CommentSection {
     return [
       CommentListOptions(onSortChanged: store.updateSorting, sortValue: sort),
       // sorting menu goes here
-      if (postComments != null && postComments.isEmpty)
+      if (postComments != null && postComments.isEmpty && newComments.isEmpty)
         _centeredWithConstraints(
           child: const Padding(
             padding: EdgeInsets.symmetric(vertical: 50),

--- a/lib/widgets/comment/comment.dart
+++ b/lib/widgets/comment/comment.dart
@@ -81,14 +81,14 @@ class CommentWidget extends StatelessWidget {
     return MobxProvider(
       create: (context) {
         return CommentStore(
-        context.read(),
-        commentTree: commentTree,
-        userMentionId: userMentionId,
-        depth: depth,
-        canBeMarkedAsRead: canBeMarkedAsRead,
-        detached: detached,
-        hideOnRead: hideOnRead,
-      );
+          context.read(),
+          commentTree: commentTree,
+          userMentionId: userMentionId,
+          depth: depth,
+          canBeMarkedAsRead: canBeMarkedAsRead,
+          detached: detached,
+          hideOnRead: hideOnRead,
+        );
       },
       builder: (context, child) => Nested(
         children: [
@@ -310,7 +310,9 @@ class _CommentWidget extends StatelessWidget {
               ),
               if (!store.collapsed)
                 for (final c in store.children)
-                  CommentWidget(c, depth: store.depth + 1, key: Key(c.comment.comment.id.toString())),
+                  CommentWidget(c,
+                      depth: store.depth + 1,
+                      key: Key(c.comment.comment.id.toString())),
             ],
           ),
         );

--- a/lib/widgets/comment/comment.dart
+++ b/lib/widgets/comment/comment.dart
@@ -79,7 +79,8 @@ class CommentWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MobxProvider(
-      create: (context) => CommentStore(
+      create: (context) {
+        return CommentStore(
         context.read(),
         commentTree: commentTree,
         userMentionId: userMentionId,
@@ -87,7 +88,8 @@ class CommentWidget extends StatelessWidget {
         canBeMarkedAsRead: canBeMarkedAsRead,
         detached: detached,
         hideOnRead: hideOnRead,
-      ),
+      );
+      },
       builder: (context, child) => Nested(
         children: [
           AsyncStoreListener<BlockedPerson>(
@@ -308,7 +310,7 @@ class _CommentWidget extends StatelessWidget {
               ),
               if (!store.collapsed)
                 for (final c in store.children)
-                  CommentWidget(c, depth: store.depth + 1),
+                  CommentWidget(c, depth: store.depth + 1, key: Key(c.comment.comment.id.toString())),
             ],
           ),
         );


### PR DESCRIPTION
Fixes for:
- #72 - This was caused by the full post comment list not looking at "newComments," so the "No comments yet" was still showing even if that list was populated
- #167 - This was caused by the comment list not having keys, so a comment widget would be appended to the top of the children, but it would reuse the same MobxProvider instead of recreating it with the new comment tree