### PR TITLE
Image preview in posts scales rather than clips

### DIFF
--- a/lib/widgets/post/post_media.dart
+++ b/lib/widgets/post/post_media.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../../util/observer_consumers.dart';
 import '../cached_network_image.dart';
-import '../clipped_image.dart';
 import '../fullscreenable_image.dart';
+import '../scaled_image.dart';
 import 'post_status.dart';
 import 'post_store.dart';
 
@@ -20,35 +20,33 @@ class PostMedia extends StatelessWidget {
         final isFullPost = context.read<IsFullPost>();
 
         final url = post.url!; // hasMedia returns false if url is null
+        // Set a max height for image previews based on
+        // screen height to ensure that a reasonable
+        // amount of other content is visible.
+        final maxHeight = MediaQuery.of(context).size.height / 3;
 
         return FullscreenableImage(
           url: url,
-          child: SizedBox(
-            height: !isFullPost ? 300 : null,
-            child: CachedNetworkImage(
-              imageUrl: url,
-              errorBuilder: (_, ___) => const Center(
-                child: Icon(Icons.warning),
-              ),
-              loadingBuilder: (context, progress) => Center(
-                child: CircularProgressIndicator.adaptive(
-                  value: progress?.progress,
-                ),
-              ),
-              imageBuilder: (context, imageProvider) {
-                if (isFullPost) {
-                  return Image(
-                    image: imageProvider,
-                  );
-                }
-
-                return FitClippedWidget(
-                  child: Image(
-                    image: imageProvider,
-                  ),
-                );
-              },
+          child: CachedNetworkImage(
+            imageUrl: url,
+            errorBuilder: (_, ___) => const Center(
+              child: Icon(Icons.warning),
             ),
+            loadingBuilder: (context, progress) => Center(
+              child: CircularProgressIndicator.adaptive(
+                value: progress?.progress,
+              ),
+            ),
+            imageBuilder: (context, imageProvider) {
+              final im = Image(image: imageProvider);
+              if (isFullPost) {
+                return im;
+              }
+              return FitScaledWidget(
+                height: maxHeight,
+                child: im,
+              );
+            },
           ),
         );
       },

--- a/lib/widgets/scaled_image.dart
+++ b/lib/widgets/scaled_image.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class FitScaledWidget extends StatelessWidget {
+  const FitScaledWidget({
+    super.key,
+    required this.child,
+    this.height = 300,
+    this.fit = BoxFit.contain,
+  });
+
+  final Widget child;
+  final double height;
+  final BoxFit fit;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints.loose(Size.fromHeight(height)),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: FittedBox(
+          fit: fit,
+          child: child,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Use scaling rather than clipping. It works better for most images, and is tolerable for weird cases.