### PR TITLE
Add scroll chainer for post body

### DIFF
--- a/lib/widgets/infinite_scroll.dart
+++ b/lib/widgets/infinite_scroll.dart
@@ -5,6 +5,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 import 'bottom_safe.dart';
 import 'pull_to_refresh.dart';
+import 'scoll_chainer.dart';
 
 class InfiniteScrollController {
   late VoidCallback clear;
@@ -101,57 +102,60 @@ class InfiniteScroll<T> extends HookWidget {
 
         await Future.delayed(const Duration(seconds: 1));
       },
-      child: ListView.builder(
-        padding: padding,
-        // +2 for the loading widget and leading widget
-        itemCount: data.value.length + 2,
-        itemBuilder: (_, i) {
-          if (i == 0) {
-            return leading;
-          }
-          i -= 1;
+      child: ScrollChainer(
+        axis: Axis.vertical,
+        child: ListView.builder(
+          padding: padding,
+          // +2 for the loading widget and leading widget
+          itemCount: data.value.length + 2,
+          itemBuilder: (_, i) {
+            if (i == 0) {
+              return leading;
+            }
+            i -= 1;
 
-          // if we are done but we have no data it means the list is empty
-          if (!hasMore.value && data.value.isEmpty) {
-            return Center(child: noItems);
-          }
-
-          // reached the bottom, fetch more
-          if (i == data.value.length) {
-            // if there are no more, skip
-            if (!hasMore.value) {
-              return const BottomSafe();
+            // if we are done but we have no data it means the list is empty
+            if (!hasMore.value && data.value.isEmpty) {
+              return Center(child: noItems);
             }
 
-            // if it's already fetching more, skip
-            if (!isFetching.value) {
-              isFetching.value = true;
-              fetcher(page.value, batchSize).then((incoming) {
-                // if got less than the batchSize, mark the list as done
-                if (incoming.length < batchSize) {
-                  hasMore.value = false;
-                }
+            // reached the bottom, fetch more
+            if (i == data.value.length) {
+              // if there are no more, skip
+              if (!hasMore.value) {
+                return const BottomSafe();
+              }
 
-                final newData = incoming.where(
-                  (e) => !dataSet.value.contains(uniquePropFunc(e)),
-                );
+              // if it's already fetching more, skip
+              if (!isFetching.value) {
+                isFetching.value = true;
+                fetcher(page.value, batchSize).then((incoming) {
+                  // if got less than the batchSize, mark the list as done
+                  if (incoming.length < batchSize) {
+                    hasMore.value = false;
+                  }
 
-                // append new data
-                data.value = [...data.value, ...newData];
-                dataSet.value.addAll(newData.map(uniquePropFunc));
-                page.value += 1;
-              }).whenComplete(() => isFetching.value = false);
+                  final newData = incoming.where(
+                    (e) => !dataSet.value.contains(uniquePropFunc(e)),
+                  );
+
+                  // append new data
+                  data.value = [...data.value, ...newData];
+                  dataSet.value.addAll(newData.map(uniquePropFunc));
+                  page.value += 1;
+                }).whenComplete(() => isFetching.value = false);
+              }
+
+              return SafeArea(
+                top: false,
+                child: loadingWidget,
+              );
             }
 
-            return SafeArea(
-              top: false,
-              child: loadingWidget,
-            );
-          }
-
-          // not last element, render list item
-          return itemBuilder(data.value[i]);
-        },
+            // not last element, render list item
+            return itemBuilder(data.value[i]);
+          },
+        ),
       ),
     );
   }

--- a/lib/widgets/scoll_chainer.dart
+++ b/lib/widgets/scoll_chainer.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('ScrollChainer');
+
+// Need to keep track of whether the user is scrolling or not, otherwise
+// the scroll animation will be overridden by the user's scroll.
+// Not using a stateful widget because it would cause an unnecessary rebuild
+// of the widget tree.
+// ignore: must_be_immutable
+class ScrollChainer extends StatelessWidget {
+  bool _scrolling = false;
+  final Widget child;
+  final Axis? axis;
+
+  ScrollChainer({required this.child, this.axis});
+
+  _getMinMaxPosition(double tryScrollTo, ScrollController controller) {
+    return tryScrollTo < controller.position.minScrollExtent
+        ? controller.position.minScrollExtent
+        : tryScrollTo > controller.position.maxScrollExtent
+            ? controller.position.maxScrollExtent
+            : tryScrollTo;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener(
+      child: child,
+      onNotification: (ScrollNotification notification) {
+        // log axis and notification axis
+        _logger.info(
+            'axis: $axis, notification.metrics.axis: ${notification.metrics.axis}');
+        if (axis != null && notification.metrics.axis != axis) {
+          return false;
+        }
+
+        final controller = PrimaryScrollController.of(context);
+
+        //users finger is still on the screen
+        if (notification is OverscrollNotification &&
+            notification.velocity == 0) {
+          final scrollTo = _getMinMaxPosition(
+              controller.position.pixels + (notification.overscroll),
+              controller);
+          controller.jumpTo(scrollTo);
+        }
+        //users finger left screen before limit of the listview was reached, but momentum takes it to the limit and beoyond
+        else if (notification is OverscrollNotification) {
+          final yVelocity = notification.velocity;
+          _scrolling =
+              true; //stops other notifiations overriding this scroll animation
+          final scrollTo = _getMinMaxPosition(
+              controller.position.pixels + (yVelocity / 5), controller);
+          controller
+              .animateTo(scrollTo,
+                  duration: const Duration(milliseconds: 1000),
+                  curve: Curves.linearToEaseOut)
+              .then((value) => _scrolling = false);
+        }
+        //users finger left screen after the limit of teh list view was reached
+        else if (notification is ScrollEndNotification &&
+            notification.depth > 0 &&
+            !_scrolling) {
+          final yVelocity =
+              notification.dragDetails?.velocity.pixelsPerSecond.dy ?? 0;
+          final scrollTo = _getMinMaxPosition(
+              controller.position.pixels - (yVelocity / 5), controller);
+          final scrollToPractical =
+              scrollTo < controller.position.minScrollExtent
+                  ? controller.position.minScrollExtent
+                  : scrollTo > controller.position.maxScrollExtent
+                      ? controller.position.maxScrollExtent
+                      : scrollTo;
+          controller.animateTo(scrollToPractical,
+              duration: const Duration(milliseconds: 1000),
+              curve: Curves.linearToEaseOut);
+        }
+
+        return false;
+      },
+    );
+  }
+}


### PR DESCRIPTION
Since the post body gets clipped when within a certian threshold of length, it's pretty annoying when scrolling gets "stuck" in the feed.

This makes it so that at the end of the nested scroll, it continues the page scroll.

To do so, I managed to implement a generic scroll chain widget that can be reused in other places for similar behavior.