### PR TITLE
Disable scrolling for community/user tab views

### DIFF
--- a/lib/pages/community/community.dart
+++ b/lib/pages/community/community.dart
@@ -120,6 +120,7 @@ class CommunityPage extends HookWidget {
                 ),
               ],
               body: TabBarView(
+                physics: const NeverScrollableScrollPhysics(),
                 children: [
                   InfinitePostList(
                     fetcher: (page, batchSize, sort) =>

--- a/lib/widgets/user_profile.dart
+++ b/lib/widgets/user_profile.dart
@@ -89,25 +89,12 @@ class UserProfile extends HookWidget {
             ),
           ),
         ],
-        body: TabBarView(children: [
-          // TODO: first batch is already fetched on render
-          // TODO: comment and post come from the same endpoint, could be shared
-          InfinitePostList(
-            fetcher: (page, batchSize, sort) => LemmyApiV3(instanceHost)
-                .run(GetPersonDetails(
-                  personId: userView.person.id,
-                  savedOnly: false,
-                  sort: SortType.active,
-                  page: page,
-                  limit: batchSize,
-                  auth: accountsStore.defaultUserDataFor(instanceHost)?.jwt.raw,
-                ))
-                .then((val) => val.posts),
-          ),
-          Center(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 600),
-              child: InfiniteCommentList(
+        body: TabBarView(
+            physics: const NeverScrollableScrollPhysics(),
+            children: [
+              // TODO: first batch is already fetched on render
+              // TODO: comment and post come from the same endpoint, could be shared
+              InfinitePostList(
                 fetcher: (page, batchSize, sort) => LemmyApiV3(instanceHost)
                     .run(GetPersonDetails(
                       personId: userView.person.id,
@@ -120,12 +107,30 @@ class UserProfile extends HookWidget {
                           ?.jwt
                           .raw,
                     ))
-                    .then((val) => val.comments),
+                    .then((val) => val.posts),
               ),
-            ),
-          ),
-          _AboutTab(fullPersonView),
-        ]),
+              Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 600),
+                  child: InfiniteCommentList(
+                    fetcher: (page, batchSize, sort) => LemmyApiV3(instanceHost)
+                        .run(GetPersonDetails(
+                          personId: userView.person.id,
+                          savedOnly: false,
+                          sort: SortType.active,
+                          page: page,
+                          limit: batchSize,
+                          auth: accountsStore
+                              .defaultUserDataFor(instanceHost)
+                              ?.jwt
+                              .raw,
+                        ))
+                        .then((val) => val.comments),
+                  ),
+                ),
+              ),
+              _AboutTab(fullPersonView),
+            ]),
       ),
     );
   }


### PR DESCRIPTION
Currently, left/right swipes are captured by the tab view to swap tabs. 

This breaks the swipe to navigate back that works everywhere else. Honestly, I think that's far more useful, so I'm changing to allow that to happen.