### PR TITLE
Make community and user share links use lemmy.guide

### DIFF
--- a/lib/pages/community/community.dart
+++ b/lib/pages/community/community.dart
@@ -72,7 +72,8 @@ class CommunityPage extends HookWidget {
         final fullCommunityView = communityAsyncState.data;
         final community = fullCommunityView.communityView;
 
-        void doShare() => share(community.community.actorId, context: context);
+        void doShare() => share(buildLemmyGuideUrl(community.community.actorId),
+            context: context);
 
         return Scaffold(
           floatingActionButton: CreatePostFab(community: community),

--- a/lib/pages/user.dart
+++ b/lib/pages/user.dart
@@ -42,7 +42,8 @@ class UserPage extends HookWidget {
           shareButtonKey.currentContext!.findRenderObject()! as RenderBox;
       final position = renderbox.localToGlobal(Offset.zero);
 
-      return share(userDetailsSnap.data!.personView.person.actorId,
+      return share(
+          buildLemmyGuideUrl(userDetailsSnap.data!.personView.person.actorId),
           context: context,
           sharePositionOrigin: Rect.fromPoints(position,
               position.translate(renderbox.size.width, renderbox.size.height)));

--- a/lib/util/share.dart
+++ b/lib/util/share.dart
@@ -37,3 +37,8 @@ Future<void> _fallbackShare(
     const SnackBar(content: Text('Copied data to clipboard!')),
   );
 }
+
+/// Constructs an instance-agnostic link to the given target,
+/// using the `lemmy.guide` service
+String buildLemmyGuideUrl(String target) =>
+    'https://lemmy.guide/link?target=$target';


### PR DESCRIPTION
As discussed in the matrix channel, this is the approach we're going to take to make shared Lemmy URLs instance-agnostic.

I also considered making this an option, but I know @mykdavies would hate that.