### PR TITLE
Improved colour theme support

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -28,17 +28,22 @@ class MyApp extends StatelessWidget {
           builder: (context, state, child) {
             return ObserverBuilder<ConfigStore>(
               builder: (context, store) => MaterialApp(
-                title: 'Liftoff',
-                supportedLocales: L10n.supportedLocales,
-                localizationsDelegates: l10nDelegates,
-                themeMode: state.theme,
-                darkTheme: themeFactory(
-                    primaryColor: state.primaryColor,
-                    amoled: state.amoled,
-                    dark: true),
-                locale: store.locale,
-                theme: themeFactory(primaryColor: state.primaryColor),
-                home: AppLinkHandler(const HomePage()),
+                // Use a builder here to ensure that AppTheme can
+                // react to platform light/dark changes.
+                builder: (context, _) {
+                  return MaterialApp(
+                      title: 'Liftoff',
+                      supportedLocales: L10n.supportedLocales,
+                      localizationsDelegates: l10nDelegates,
+                      themeMode: state.theme,
+                      theme: themeFactory(primaryColor: state.primaryColor),
+                      darkTheme: themeFactory(
+                          primaryColor: state.primaryColor,
+                          amoled: state.useAmoled,
+                          dark: true),
+                      locale: store.locale,
+                      home: AppLinkHandler(const HomePage()));
+                },
               ),
             );
           },

--- a/lib/pages/settings/settings.dart
+++ b/lib/pages/settings/settings.dart
@@ -111,19 +111,12 @@ class AppearanceConfigPage extends StatelessWidget {
                   onChanged: (selected) {
                     if (selected != null) {
                       state.switchtheme(selected);
-                      if (selected == ThemeMode.dark) {
-                        state.setPrimaryColor(
-                            ThemeData.dark().colorScheme.secondary);
-                      } else {
-                        state.setPrimaryColor(
-                            ThemeData.light().colorScheme.primary);
-                      }
                     }
                   },
                 ),
               SwitchListTile.adaptive(
                 title: Text(L10n.of(context).amoled_dark_mode),
-                value: state.amoled,
+                value: state.amoledWanted,
                 onChanged: (checked) => state.switchamoled(),
               ),
               ListTile(
@@ -134,6 +127,7 @@ class AppearanceConfigPage extends StatelessWidget {
                     Text(L10n.of(context).primary_color),
                     IconButton(
                       onPressed: () {
+                        // Pull default values from the system themes
                         if (state.theme == ThemeMode.dark) {
                           state.setPrimaryColor(
                               ThemeData.dark().colorScheme.secondary);
@@ -374,12 +368,12 @@ class PostStyleConfigPage extends StatelessWidget {
                       IgnorePointer(
                           child: PostTile.fromPostView(PostView.fromJson(
                               decoder.convert(mockTextPostJson)))),
-                      if (state.amoled) gradient,
+                      if (state.useAmoled) gradient,
                       SizedBox(height: store.compactPostView ? 2 : 10),
                       IgnorePointer(
                           child: PostTile.fromPostView(PostView.fromJson(
                               decoder.convert(mockMediaPost)))),
-                      if (state.amoled) gradient,
+                      if (state.useAmoled) gradient,
                       SizedBox(height: store.compactPostView ? 2 : 10),
                       IgnorePointer(
                           child: PostTile.fromPostView(PostView.fromJson(

--- a/lib/resources/app_theme.dart
+++ b/lib/resources/app_theme.dart
@@ -1,30 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AppTheme extends ChangeNotifier {
   final String themeKey = 'theme';
   final String amoledKey = 'amoled';
-  final String primaryKey = 'primary';
+  final String primaryColorDarkKey = 'primaryColorDark';
+  final String primaryColorLightKey = 'primaryColorLight';
 
   SharedPreferences? _prefs;
   bool _amoled = false;
-  ThemeMode _theme = ThemeMode.dark;
-  Color _primaryColor = ThemeData().colorScheme.secondary;
+  late ThemeMode _theme;
 
-  bool get amoled => _amoled;
+  Color _primaryColorDark = ThemeData.dark().colorScheme.secondary;
+  Color _primaryColorLight = ThemeData.light().colorScheme.primary;
+
+  // Reports user preference whether to use amoled.
+  bool get amoledWanted => _amoled;
+  // System decision whether we should be using amoled right now.
+  bool get useAmoled => areWeDark && _amoled;
   ThemeMode get theme => _theme;
-  Color get primaryColor => _primaryColor;
+  Color get primaryColor => areWeDark ? _primaryColorDark : _primaryColorLight;
 
   AppTheme() {
-    _theme = ThemeMode.dark;
     _loadprefs();
   }
 
+  bool get isSystemDark =>
+      SchedulerBinding.instance.platformDispatcher.platformBrightness ==
+      Brightness.dark;
+
+  bool get areWeDark =>
+      theme == ThemeMode.dark || (theme == ThemeMode.system && isSystemDark);
+
   void switchtheme(ThemeMode theme) {
     _theme = theme;
-    if (theme != ThemeMode.dark) {
-      _amoled = false;
-    }
+
     _saveprefs();
     notifyListeners();
   }
@@ -36,7 +47,11 @@ class AppTheme extends ChangeNotifier {
   }
 
   void setPrimaryColor(Color color) {
-    _primaryColor = color;
+    if (areWeDark) {
+      _primaryColorDark = color;
+    } else {
+      _primaryColorLight = color;
+    }
     _saveprefs();
     notifyListeners();
   }
@@ -45,16 +60,19 @@ class AppTheme extends ChangeNotifier {
     _prefs ??= await SharedPreferences.getInstance();
   }
 
+  // Set sensible default values for ThemeMode and primaryColor
   _loadprefs() async {
     await _initiateprefs();
-    _theme = ThemeMode.values[_prefs?.getInt(themeKey) ?? 2];
+
+    // Default new installations to following the system theme.
+    final oldMode = _prefs?.getInt(themeKey);
+    _theme = (oldMode == null) ? ThemeMode.system : ThemeMode.values[oldMode];
+
     _amoled = _prefs?.getBool(amoledKey) ?? false;
-
-    final defaultPrimary = _theme == ThemeMode.light
-        ? ThemeData.light().colorScheme.primary
-        : ThemeData.dark().colorScheme.secondary;
-    _primaryColor = Color(_prefs?.getInt(primaryKey) ?? defaultPrimary.value);
-
+    _primaryColorDark =
+        Color(_prefs?.getInt(primaryColorDarkKey) ?? _primaryColorDark.value);
+    _primaryColorLight =
+        Color(_prefs?.getInt(primaryColorLightKey) ?? _primaryColorLight.value);
     notifyListeners();
   }
 
@@ -62,6 +80,7 @@ class AppTheme extends ChangeNotifier {
     await _initiateprefs();
     await _prefs?.setInt(themeKey, _theme.index);
     await _prefs?.setBool(amoledKey, _amoled);
-    await _prefs?.setInt(primaryKey, _primaryColor.value);
+    await _prefs?.setInt(primaryColorDarkKey, _primaryColorDark.value);
+    await _prefs?.setInt(primaryColorLightKey, _primaryColorLight.value);
   }
 }

--- a/lib/widgets/sortable_infinite_list.dart
+++ b/lib/widgets/sortable_infinite_list.dart
@@ -132,7 +132,7 @@ class InfinitePostList extends SortableInfiniteList<PostView> {
               builder: (context, state, child) => Column(
                     children: [
                       PostTile.fromPostView(post),
-                      if (state.amoled)
+                      if (state.useAmoled)
                         SizedBox(
                           width: 250,
                           height: 1,


### PR DESCRIPTION
One line turned into many.

I've run it on Android and it looks okay I think, but a review would be wise.

I would also appreciate a close review as it does change app.dart.

Summary:
- Changed the default to follow system. 
- Made AMOLED choice persistent and added logic to decide when to apply that choice.
- Cleaned up the odd implementation of primaryColor.
- Made primaryColor follow system-driven theme changes.

Known issue
- will reset colour choices made in previous setup (one off).

