### PR TITLE
Fix generated lemmy.guide URLs

### DIFF
--- a/lib/pages/community/community.dart
+++ b/lib/pages/community/community.dart
@@ -72,7 +72,9 @@ class CommunityPage extends HookWidget {
         final fullCommunityView = communityAsyncState.data;
         final community = fullCommunityView.communityView;
 
-        void doShare() => share(buildLemmyGuideUrl(community.community.actorId),
+        void doShare() => share(
+            buildLemmyGuideUrl(
+                '!${community.community.name}@${community.instanceHost}'),
             context: context);
 
         return Scaffold(

--- a/lib/pages/user.dart
+++ b/lib/pages/user.dart
@@ -43,7 +43,8 @@ class UserPage extends HookWidget {
       final position = renderbox.localToGlobal(Offset.zero);
 
       return share(
-          buildLemmyGuideUrl(userDetailsSnap.data!.personView.person.actorId),
+          buildLemmyGuideUrl(
+              '@${userDetailsSnap.data!.personView.person.name}@$instanceHost'),
           context: context,
           sharePositionOrigin: Rect.fromPoints(position,
               position.translate(renderbox.size.width, renderbox.size.height)));


### PR DESCRIPTION
For some reason `actorId` became full http urls recently.
This was kind of not good for lemmy.guide, which expected user-facing strings.