### PR TITLE
De-duplicate contents of infinite scroll

### DIFF
--- a/lib/widgets/infinite_scroll.dart
+++ b/lib/widgets/infinite_scroll.dart
@@ -51,9 +51,7 @@ class InfiniteScroll<T> extends HookWidget {
 
   /// Maps an item to its unique property that will allow to detect possible
   /// duplicates thus perfoming deduplication
-  final Object Function(T item)? uniqueProp;
-
-  Object _defaultUniqueProp(T item) => item as Object;
+  final Object Function(T item) uniqueProp;
 
   /// If true, all content will be discarded and refetched when value
   /// of [fetcher] changes.
@@ -74,7 +72,7 @@ class InfiniteScroll<T> extends HookWidget {
     this.controller,
     this.noItems = const SizedBox.shrink(),
     this.refreshOnFetcherUpdate = false,
-    this.uniqueProp,
+    required this.uniqueProp,
   }) : assert(batchSize > 0);
 
   @override
@@ -99,7 +97,7 @@ class InfiniteScroll<T> extends HookWidget {
       try {
         final newItems = await fetcher(pageKey, batchSize);
         final uniqueNewItems = newItems.where((item) {
-          final uniquePropValue = (uniqueProp ?? _defaultUniqueProp)(item);
+          final uniquePropValue = uniqueProp(item);
           if (dataSet.value.contains(uniquePropValue)) {
             return false;
           }

--- a/lib/widgets/infinite_scroll.dart
+++ b/lib/widgets/infinite_scroll.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
@@ -51,6 +53,8 @@ class InfiniteScroll<T> extends HookWidget {
   /// duplicates thus perfoming deduplication
   final Object Function(T item)? uniqueProp;
 
+  Object _defaultUniqueProp(T item) => item as Object;
+
   /// If true, all content will be discarded and refetched when value
   /// of [fetcher] changes.
   ///
@@ -87,19 +91,30 @@ class InfiniteScroll<T> extends HookWidget {
       return null;
     }, []);
 
+    final dataSet = useRef(HashSet<Object>());
+
     // Need to memoize the callback so we get a single instance
     // that we can add/remove from the controller.
     final pageRequestListener = useCallback((pageKey) async {
       try {
-        final items = await fetcher(pageKey, batchSize);
-        // TODO: check if deduplication is needed
-        // final uniqueItems =
-        //     uniqueProp == null ? items : LinkedHashSet<T>.from(items).toList();
-        final isLastPage = items.length < batchSize;
+        final newItems = await fetcher(pageKey, batchSize);
+        final uniqueNewItems = newItems.where((item) {
+          final uniquePropValue = (uniqueProp ?? _defaultUniqueProp)(item);
+          if (dataSet.value.contains(uniquePropValue)) {
+            return false;
+          }
+
+          dataSet.value.add(uniquePropValue);
+          return true;
+        }).toList();
+
+        // If we got less than `batchSize` items, then we reached the end.
+        // Note: we're checking `newItems` and not `uniqueNewItems`.
+        final isLastPage = newItems.length < batchSize;
         if (isLastPage) {
-          pagingController.appendLastPage(items);
+          pagingController.appendLastPage(uniqueNewItems);
         } else {
-          pagingController.appendPage(items, pageKey + 1);
+          pagingController.appendPage(uniqueNewItems, pageKey + 1);
         }
       } catch (error) {
         pagingController.error = error;

--- a/lib/widgets/post/post.dart
+++ b/lib/widgets/post/post.dart
@@ -87,7 +87,6 @@ class _Post extends HookWidget {
       onTap: isFullPost
           ? null
           : () {
-              final postStore = context.read<PostStore>();
               Navigator.of(context)
                   .push(FullPostPage.fromPostStoreRoute(postStore));
             },

--- a/lib/widgets/sortable_infinite_list.dart
+++ b/lib/widgets/sortable_infinite_list.dart
@@ -30,7 +30,7 @@ class SortableInfiniteList<T> extends HookWidget {
   /// if no defaultSort is provided, the defaultSortType
   /// from the configStore will be used
   final SortType? defaultSort;
-  final Object Function(T item)? uniqueProp;
+  final Object Function(T item) uniqueProp;
   const SortableInfiniteList({
     super.key,
     required this.fetcher,
@@ -40,7 +40,7 @@ class SortableInfiniteList<T> extends HookWidget {
     this.noItems = const SizedBox.shrink(),
     this.defaultSort,
     this.refreshOnFetcherUpdate = false,
-    this.uniqueProp,
+    required this.uniqueProp,
   });
 
   @override
@@ -88,7 +88,7 @@ class SortableInfiniteCommentList<T> extends HookWidget {
   /// if no defaultSort is provided, the defaultSortType
   /// from the configStore will be used
   final dynamic defaultSort;
-  final Object Function(T item)? uniqueProp;
+  final Object Function(T item) uniqueProp;
   const SortableInfiniteCommentList({
     super.key,
     required this.fetcher,
@@ -97,7 +97,7 @@ class SortableInfiniteCommentList<T> extends HookWidget {
     this.onStyleChange,
     this.noItems = const SizedBox.shrink(),
     this.defaultSort,
-    this.uniqueProp,
+    required this.uniqueProp,
   });
 
   @override


### PR DESCRIPTION
Addresses a `TODO` comment I left in #424.
Also improves performance (probably because there's now less renders.