### PR TITLE
Use translated string value rather than raw value for post sort, comment sort, and default listing setting dropdowns

### DIFF
--- a/lib/l10n/l10n_api.dart
+++ b/lib/l10n/l10n_api.dart
@@ -40,6 +40,23 @@ extension SortTypeL10n on SortType {
   }
 }
 
+extension CommentSortTypeL10n on CommentSortType {
+  String tr(BuildContext context) {
+    switch (this) {
+      case CommentSortType.hot:
+        return L10n.of(context).hot;
+      case CommentSortType.new_:
+        return L10n.of(context).new_;
+      case CommentSortType.old:
+        return L10n.of(context).old;
+      case CommentSortType.top:
+        return L10n.of(context).top;
+      default:
+        throw Exception('unreachable');
+    }
+  }
+}
+
 extension PostListingTypeL10n on PostListingType {
   String tr(BuildContext context) {
     switch (this) {

--- a/lib/pages/settings/settings.dart
+++ b/lib/pages/settings/settings.dart
@@ -629,7 +629,7 @@ class GeneralConfigPage extends StatelessWidget {
                   values: SortType.values,
                   groupValue: store.defaultSortType,
                   onChanged: (value) => store.defaultSortType = value,
-                  mapValueToString: (value) => value.value,
+                  mapValueToString: (value) => value.tr(context),
                   buttonBuilder: (context, displayValue, onPressed) =>
                       FilledButton(
                     onPressed: onPressed,

--- a/lib/pages/settings/settings.dart
+++ b/lib/pages/settings/settings.dart
@@ -653,7 +653,7 @@ class GeneralConfigPage extends StatelessWidget {
                       .sublist(0, CommentSortType.values.length - 1),
                   groupValue: store.defaultCommentSort,
                   onChanged: (value) => store.defaultCommentSort = value,
-                  mapValueToString: (value) => value.value,
+                  mapValueToString: (value) => value.tr(context),
                   buttonBuilder: (context, displayValue, onPressed) =>
                       FilledButton(
                     onPressed: onPressed,
@@ -680,7 +680,7 @@ class GeneralConfigPage extends StatelessWidget {
                   ],
                   groupValue: store.defaultListingType,
                   onChanged: (value) => store.defaultListingType = value,
-                  mapValueToString: (value) => value.value,
+                  mapValueToString: (value) => value.tr(context),
                   buttonBuilder: (context, displayValue, onPressed) =>
                       FilledButton(
                     onPressed: onPressed,


### PR DESCRIPTION
Fixes #453

Edit: I've realized that this issue affects two other dropdowns, so I commited the fix and added a comment on my issue to describe the other problems.